### PR TITLE
[#1] Strava OAuth refresh-token script and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,38 @@ The one exception to "no server-side processing" is `downsample_to_seconds` on s
 
 ## Strava app setup
 
-1. Go to [developers.strava.com](https://www.strava.com/settings/api) and create an app.
-2. Set **Authorization Callback Domain** to `localhost` for now.
-3. Note your **Client ID** and **Client Secret**.
-4. The exact OAuth scopes this server uses: `read,activity:read_all,profile:read_all`
-   - `activity:write`, `profile:write`, and all other write scopes must **never** be requested. This MCP is read-only by design.
-5. After getting your Client ID and Secret, follow **issue #1** to obtain your refresh token.
+### Step 1 — Register a Strava API app
+
+1. Go to [https://www.strava.com/settings/api](https://www.strava.com/settings/api) and create an app.
+2. Fill in any name and website (e.g. `http://localhost`).
+3. Set **Authorization Callback Domain** to `localhost`.
+4. Submit. Note your **Client ID** and **Client Secret** from the app page.
+
+The exact OAuth scopes this server requests: **`read,activity:read_all,profile:read_all`**
+
+`activity:write`, `profile:write`, and all other write scopes are never requested — this MCP is read-only by design.
+
+### Step 2 — Get your refresh token
+
+Add your Client ID and Secret to `.dev.vars`, then run:
+
+```bash
+pnpm get-refresh-token
+```
+
+This opens Strava in your browser, asks you to authorise the app, captures the callback, and prints your refresh token to the terminal. The refresh token is long-lived (doesn't expire unless you revoke it) — you only need to run this once.
+
+Copy the printed `STRAVA_REFRESH_TOKEN` into your `.dev.vars` file.
+
+### Step 3 — Set Cloudflare Worker secrets (after deploying)
+
+```bash
+npx wrangler secret put STRAVA_CLIENT_ID
+npx wrangler secret put STRAVA_CLIENT_SECRET
+npx wrangler secret put STRAVA_REFRESH_TOKEN
+```
+
+Paste each value when prompted. These secrets are stored encrypted by Cloudflare and never appear in your code or wrangler.jsonc.
 
 ---
 
@@ -111,5 +137,6 @@ pnpm test:run   # run tests once
 pnpm lint       # ESLint
 pnpm lint:fix   # ESLint with autofix
 pnpm typecheck  # TypeScript type checking
-pnpm tail       # stream live Worker logs (wrangler tail)
+pnpm tail              # stream live Worker logs (wrangler tail)
+pnpm get-refresh-token # run the Strava OAuth flow to get a refresh token
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail",
+    "get-refresh-token": "tsx scripts/get-refresh-token.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
@@ -28,6 +29,7 @@
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.1.3",
+    "tsx": "^4.19.4",
     "wrangler": "^4.86.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       agents:
         specifier: 0.11.6
-        version: 0.11.6(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260426.1)(ai@6.0.168(zod@3.25.76))(react@19.2.5)(rolldown@1.0.0-rc.17)(vite@7.3.2)(zod@3.25.76)
+        version: 0.11.6(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260426.1)(ai@6.0.168(zod@3.25.76))(react@19.2.5)(rolldown@1.0.0-rc.17)(vite@7.3.2(tsx@4.21.0))(zod@3.25.76)
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8.30
-        version: 0.8.71(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)
+        version: 0.8.71(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(tsx@4.21.0))
       '@cloudflare/workers-types':
         specifier: ^4.20250422.0
         version: 4.20260426.1
@@ -36,6 +36,9 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.8.3
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
@@ -44,7 +47,7 @@ importers:
         version: 8.59.1(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4
+        version: 3.2.4(tsx@4.21.0)
       wrangler:
         specifier: ^4.86.0
         version: 4.86.0(@cloudflare/workers-types@4.20260426.1)
@@ -1993,6 +1996,9 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -2405,6 +2411,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2555,6 +2564,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2988,7 +3002,7 @@ snapshots:
     optionalDependencies:
       workerd: 1.20250906.0
 
-  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)':
+  '@cloudflare/vitest-pool-workers@0.8.71(@cloudflare/workers-types@4.20260426.1)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(tsx@4.21.0))':
     dependencies:
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2997,7 +3011,7 @@ snapshots:
       devalue: 5.7.1
       miniflare: 4.20250906.0
       semver: 7.7.4
-      vitest: 3.2.4
+      vitest: 3.2.4(tsx@4.21.0)
       wrangler: 4.35.0(@cloudflare/workers-types@4.20260426.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -3645,14 +3659,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@7.3.2)':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@7.3.2(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.17
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      vite: 7.3.2
+      vite: 7.3.2(tsx@4.21.0)
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
@@ -3854,13 +3868,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2)':
+  '@vitest/mocker@3.2.4(vite@7.3.2(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2
+      vite: 7.3.2(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3903,12 +3917,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agents@0.11.6(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260426.1)(ai@6.0.168(zod@3.25.76))(react@19.2.5)(rolldown@1.0.0-rc.17)(vite@7.3.2)(zod@3.25.76):
+  agents@0.11.6(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260426.1)(ai@6.0.168(zod@3.25.76))(react@19.2.5)(rolldown@1.0.0-rc.17)(vite@7.3.2(tsx@4.21.0))(zod@3.25.76):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@7.3.2)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.17)(vite@7.3.2(tsx@4.21.0))
       ai: 6.0.168(zod@3.25.76)
       cron-schedule: 6.0.0
       mimetext: 3.0.28
@@ -3919,7 +3933,7 @@ snapshots:
       yargs: 18.0.0
       zod: 3.25.76
     optionalDependencies:
-      vite: 7.3.2
+      vite: 7.3.2(tsx@4.21.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/plugin-transform-runtime'
@@ -4429,6 +4443,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -4767,6 +4785,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -5015,6 +5035,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5070,13 +5097,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2
+      vite: 7.3.2(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5091,7 +5118,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2:
+  vite@7.3.2(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5101,12 +5128,13 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4:
+  vitest@3.2.4(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2)
+      '@vitest/mocker': 3.2.4(vite@7.3.2(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5124,8 +5152,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2
-      vite-node: 3.2.4
+      vite: 7.3.2(tsx@4.21.0)
+      vite-node: 3.2.4(tsx@4.21.0)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/scripts/get-refresh-token.ts
+++ b/scripts/get-refresh-token.ts
@@ -16,6 +16,7 @@ import http from "node:http";
 import { URL } from "node:url";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 
 // ---------------------------------------------------------------------------
 // Load env from .dev.vars if the values aren't already in process.env
@@ -176,7 +177,6 @@ server.listen(PORT, () => {
 
   // Open browser
   const platform = process.platform;
-  const { execSync } = await import("node:child_process");
   try {
     if (platform === "darwin") {
       execSync(`open "${authUrl}"`);

--- a/scripts/get-refresh-token.ts
+++ b/scripts/get-refresh-token.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot script to perform the Strava OAuth flow and obtain a long-lived refresh token.
+ *
+ * Usage:
+ *   STRAVA_CLIENT_ID=<id> STRAVA_CLIENT_SECRET=<secret> pnpm tsx scripts/get-refresh-token.ts
+ *
+ * Or add them to .dev.vars and run:
+ *   pnpm tsx scripts/get-refresh-token.ts
+ *
+ * After running, paste the printed STRAVA_REFRESH_TOKEN into .dev.vars
+ * and set it as a Worker secret with: npx wrangler secret put STRAVA_REFRESH_TOKEN
+ */
+
+import http from "node:http";
+import { URL } from "node:url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Load env from .dev.vars if the values aren't already in process.env
+// ---------------------------------------------------------------------------
+function loadDevVars(): void {
+  try {
+    const devVars = readFileSync(join(process.cwd(), ".dev.vars"), "utf-8");
+    for (const line of devVars.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      const value = trimmed.slice(eq + 1).trim();
+      if (key && value && !process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .dev.vars not found — rely on environment variables
+  }
+}
+
+loadDevVars();
+
+const CLIENT_ID = process.env.STRAVA_CLIENT_ID;
+const CLIENT_SECRET = process.env.STRAVA_CLIENT_SECRET;
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+  console.error(
+    "\nError: STRAVA_CLIENT_ID and STRAVA_CLIENT_SECRET must be set.\n" +
+      "Either add them to .dev.vars or export them in your shell before running this script.\n"
+  );
+  process.exit(1);
+}
+
+const PORT = 3000;
+const CALLBACK_URL = `http://localhost:${PORT}/callback`;
+const SCOPES = "read,activity:read_all,profile:read_all";
+
+const authUrl =
+  `https://www.strava.com/oauth/authorize` +
+  `?client_id=${CLIENT_ID}` +
+  `&redirect_uri=${encodeURIComponent(CALLBACK_URL)}` +
+  `&response_type=code` +
+  `&approval_prompt=force` +
+  `&scope=${SCOPES}`;
+
+// ---------------------------------------------------------------------------
+// Start a local HTTP server to receive the OAuth callback
+// ---------------------------------------------------------------------------
+const server = http.createServer(async (req, res) => {
+  if (!req.url?.startsWith("/callback")) {
+    res.writeHead(404);
+    res.end("Not found");
+    return;
+  }
+
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const error = url.searchParams.get("error");
+  const code = url.searchParams.get("code");
+
+  if (error) {
+    const message = `Strava returned an error: ${error}`;
+    res.writeHead(400, { "Content-Type": "text/html" });
+    res.end(`<h1>Error</h1><p>${message}</p><p>You can close this tab.</p>`);
+    console.error(`\n${message}\n`);
+    server.close();
+    process.exit(1);
+  }
+
+  if (!code) {
+    res.writeHead(400, { "Content-Type": "text/html" });
+    res.end("<h1>Error</h1><p>No authorization code received.</p>");
+    server.close();
+    process.exit(1);
+  }
+
+  // Exchange authorization code for tokens
+  let tokenData: {
+    access_token: string;
+    refresh_token: string;
+    expires_at: number;
+    athlete: { firstname: string; lastname: string; id: number };
+  };
+
+  try {
+    const tokenResponse = await fetch("https://www.strava.com/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        code,
+        grant_type: "authorization_code",
+      }),
+    });
+
+    if (!tokenResponse.ok) {
+      const body = await tokenResponse.text();
+      throw new Error(`Token exchange failed (${tokenResponse.status}): ${body}`);
+    }
+
+    tokenData = (await tokenResponse.json()) as typeof tokenData;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.writeHead(500, { "Content-Type": "text/html" });
+    res.end(`<h1>Error</h1><p>${message}</p>`);
+    console.error(`\nToken exchange error: ${message}\n`);
+    server.close();
+    process.exit(1);
+  }
+
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(
+    `<h1>Success!</h1>` +
+      `<p>Authenticated as ${tokenData.athlete.firstname} ${tokenData.athlete.lastname}.</p>` +
+      `<p>Your refresh token has been printed to the terminal. You can close this tab.</p>`
+  );
+
+  server.close();
+
+  const expiresAt = new Date(tokenData.expires_at * 1000).toISOString();
+
+  console.log(`
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  SUCCESS — authenticated as ${tokenData.athlete.firstname} ${tokenData.athlete.lastname} (ID: ${tokenData.athlete.id})
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  STRAVA_REFRESH_TOKEN=${tokenData.refresh_token}
+
+  (Access token expires at ${expiresAt} — the refresh token does not expire)
+
+Next steps:
+  1. Copy STRAVA_REFRESH_TOKEN into your .dev.vars file
+  2. Set it as a Worker secret after deploying:
+       npx wrangler secret put STRAVA_REFRESH_TOKEN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+`);
+});
+
+server.listen(PORT, () => {
+  console.log(`
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Strava OAuth — get-refresh-token
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  Listening on http://localhost:${PORT}/callback
+  Scopes: ${SCOPES}
+
+  Opening Strava authorization in your browser...
+  If it doesn't open automatically, visit:
+
+  ${authUrl}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+`);
+
+  // Open browser
+  const platform = process.platform;
+  const { execSync } = await import("node:child_process");
+  try {
+    if (platform === "darwin") {
+      execSync(`open "${authUrl}"`);
+    } else if (platform === "win32") {
+      execSync(`start "" "${authUrl}"`);
+    } else {
+      execSync(`xdg-open "${authUrl}"`);
+    }
+  } catch {
+    // Browser open failed — user can use the URL printed above
+  }
+});
+
+server.on("error", (err: NodeJS.ErrnoException) => {
+  if (err.code === "EADDRINUSE") {
+    console.error(
+      `\nError: Port ${PORT} is already in use.\n` +
+        `Stop whatever is running on that port and try again.\n`
+    );
+  } else {
+    console.error(`\nServer error: ${err.message}\n`);
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/get-refresh-token.ts` — a one-shot local script that handles the full Strava OAuth dance (opens browser, captures callback, exchanges code for tokens, prints refresh token)
- Requests only `read,activity:read_all,profile:read_all` scopes — no write scopes
- Adds `tsx` as a dev dependency; run with `pnpm get-refresh-token`
- Updates README with step-by-step Strava app registration instructions, refresh-token workflow, and Cloudflare Worker secrets setup

## Test plan

- [ ] Add `STRAVA_CLIENT_ID` and `STRAVA_CLIENT_SECRET` to `.dev.vars`
- [ ] Run `pnpm get-refresh-token` — browser should open to Strava authorization
- [ ] Authorise the app — terminal should print the refresh token
- [ ] Copy the refresh token into `.dev.vars` as `STRAVA_REFRESH_TOKEN`
- [ ] Confirm the scopes on the Strava authorisation page match: `read,activity:read_all,profile:read_all`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)