### PR TITLE
[#3–#9] All 7 Strava MCP tools + streams module

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ See **issue #12** for the full first-deploy walkthrough.
 
 ## Available tools
 
-| Tool | Description | Issue |
-|------|-------------|-------|
-| `get_athlete_profile` | Athlete profile (name, FTP, weight, zones config) | #3 |
-| `get_recent_activities` | List activities with filters (type, date range, limit) | #4 |
-| `get_activity_details` | Full activity breakdown — laps, splits, best efforts, segments | #5 |
-| `get_activity_streams` | Raw per-second stream data (HR, pace, cadence, altitude, etc.) | #6 |
-| `get_activity_zones` | HR and power zone distribution for an activity | #7 |
-| `get_athlete_zones` | Athlete's configured HR and power zone thresholds | #8 |
-| `get_athlete_stats` | Recent / YTD / all-time totals by sport | #9 |
+| Tool | Description | Status |
+|------|-------------|--------|
+| `get_athlete_profile` | Athlete profile: name, location, weight, FTP, measurement preference | ✅ |
+| `get_recent_activities` | List activities with filters: type, date range, limit (default 30, max 200) | ✅ |
+| `get_activity_details` | Full activity: laps, splits, best efforts, segment efforts, all metadata | ✅ |
+| `get_activity_streams` | Raw per-second stream data (HR, pace, cadence, altitude, etc.) — no smoothing | ✅ |
+| `get_activity_zones` | HR and power zone distribution for an activity, as Strava reports it | ✅ |
+| `get_athlete_zones` | Athlete's configured HR and power zone thresholds | ✅ |
+| `get_athlete_stats` | Recent (4 weeks) / YTD / all-time totals by sport | ✅ |
 | `get_segment_details` | Segment info and athlete PR | #13 |
 | `list_my_segment_efforts` | All efforts on a segment over time | #14 |
 | `get_segment_effort_streams` | Per-second streams for a single segment effort | #15 |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.29.0",
-    "agents": "0.11.6"
+    "agents": "0.11.6",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.8.30",
@@ -26,10 +27,10 @@
     "eslint-config-prettier": "^10.0.0",
     "lefthook": "^1.11.13",
     "prettier": "^3.0.0",
+    "tsx": "^4.19.4",
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.0.0",
     "vitest": "^3.1.3",
-    "tsx": "^4.19.4",
     "wrangler": "^4.86.0"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       agents:
         specifier: 0.11.6
         version: 0.11.6(@babel/core@7.29.0)(@babel/runtime@7.29.2)(@cloudflare/workers-types@4.20260426.1)(ai@6.0.168(zod@3.25.76))(react@19.2.5)(rolldown@1.0.0-rc.17)(vite@7.3.2(tsx@4.21.0))(zod@3.25.76)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.8.30

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ function buildMcpServer(env: Env): McpServer {
     version: "0.1.0",
   });
   const client = new StravaClient(env);
-  registerStravaTools(server, client);
+  registerStravaTools(server, client, env.STREAM_CACHE);
   return server;
 }
 

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -9,10 +9,233 @@ export interface StreamsParams {
   format?: "arrays" | "rows";
 }
 
-// Stub: implemented in issue #6
+const DEFAULT_STREAM_TYPES: StreamType[] = [
+  "time",
+  "distance",
+  "heartrate",
+  "velocity_smooth",
+  "altitude",
+  "cadence",
+];
+
+const ALL_STREAM_TYPES: StreamType[] = [
+  "time",
+  "distance",
+  "latlng",
+  "altitude",
+  "velocity_smooth",
+  "heartrate",
+  "cadence",
+  "watts",
+  "temp",
+  "moving",
+  "grade_smooth",
+];
+
+const GAP_THRESHOLD_SECONDS = 5;
+
+interface RawStream {
+  type: StreamType;
+  data: (number | number[] | boolean | null)[];
+  series_type: string;
+  original_size: number;
+  resolution: string;
+}
+
+interface GapLocation {
+  start_index: number;
+  end_index: number;
+  duration_seconds: number;
+}
+
+interface StreamsMetadata {
+  original_size: number;
+  resolution_returned: string;
+  downsampled_to_seconds: number | null;
+  stream_types_present: StreamType[];
+  stream_types_missing: StreamType[];
+  gap_count: number;
+  gap_locations: GapLocation[];
+}
+
+type ArraysFormat = Record<string, (number | number[] | boolean | null)[]>;
+type RowsFormat = Record<string, number | number[] | boolean | null>[];
+
+export interface StreamsResult {
+  metadata: StreamsMetadata;
+  data: ArraysFormat | RowsFormat;
+}
+
 export async function fetchActivityStreams(
-  _client: StravaClient,
-  _params: StreamsParams
-): Promise<unknown> {
-  throw new Error("Not implemented — see issue #6");
+  client: StravaClient,
+  streamCache: KVNamespace,
+  params: StreamsParams
+): Promise<StreamsResult> {
+  const {
+    activityId,
+    streamTypes = DEFAULT_STREAM_TYPES,
+    resolution = "all",
+    downsampleToSeconds,
+    format = "arrays",
+  } = params;
+
+  const requestedTypes = streamTypes.filter((t): t is StreamType =>
+    ALL_STREAM_TYPES.includes(t)
+  );
+
+  // Fetch raw streams — cache by activity ID (activities are immutable)
+  const cacheKey = `streams:${activityId}:all`;
+  let rawStreams: Record<string, RawStream>;
+
+  const cached = await streamCache.get(cacheKey);
+  if (cached) {
+    rawStreams = JSON.parse(cached) as Record<string, RawStream>;
+  } else {
+    const keys = ALL_STREAM_TYPES.join(",");
+    const query = `?keys=${keys}&resolution=all&series_type=time`;
+    const response = await client.fetch(`/activities/${activityId}/streams${query}`);
+    if (!response.ok) {
+      throw Object.assign(new Error(`Strava API error: ${response.status}`), {
+        status: response.status,
+      });
+    }
+    const streamsArray = (await response.json()) as RawStream[];
+    rawStreams = Object.fromEntries(streamsArray.map((s) => [s.type, s]));
+    await streamCache.put(cacheKey, JSON.stringify(rawStreams), {
+      expirationTtl: 30 * 24 * 60 * 60,
+    });
+  }
+
+  const presentTypes = requestedTypes.filter((t) => rawStreams[t] !== undefined);
+  const missingTypes = requestedTypes.filter((t) => rawStreams[t] === undefined);
+
+  const timeStream = rawStreams["time"];
+  const originalSize = timeStream?.data?.length ?? 0;
+
+  // Detect gaps in the time stream
+  const { gapCount, gapLocations } = detectGaps(timeStream?.data as number[] | undefined);
+
+  // Downsample if requested
+  let outputData: Record<string, (number | number[] | boolean | null)[]>;
+  if (downsampleToSeconds && downsampleToSeconds > 1 && timeStream) {
+    outputData = downsample(rawStreams, presentTypes, downsampleToSeconds);
+  } else {
+    outputData = Object.fromEntries(
+      presentTypes.map((t) => [t, rawStreams[t].data as (number | number[] | boolean | null)[]])
+    );
+  }
+
+  const resolutionReturned =
+    resolution === "all" ? "all" : (timeStream?.resolution ?? "high");
+
+  const metadata: StreamsMetadata = {
+    original_size: originalSize,
+    resolution_returned: resolutionReturned,
+    downsampled_to_seconds: downsampleToSeconds ?? null,
+    stream_types_present: presentTypes,
+    stream_types_missing: missingTypes,
+    gap_count: gapCount,
+    gap_locations: gapLocations,
+  };
+
+  if (format === "rows") {
+    const length = outputData["time"]?.length ?? outputData[presentTypes[0]]?.length ?? 0;
+    const rows: RowsFormat = [];
+    for (let i = 0; i < length; i++) {
+      const row: Record<string, number | number[] | boolean | null> = {};
+      for (const t of presentTypes) {
+        row[t] = (outputData[t]?.[i] ?? null) as number | number[] | boolean | null;
+      }
+      rows.push(row);
+    }
+    return { metadata, data: rows };
+  }
+
+  return { metadata, data: outputData };
+}
+
+function detectGaps(
+  timeData: number[] | undefined
+): { gapCount: number; gapLocations: GapLocation[] } {
+  if (!timeData || timeData.length < 2) {
+    return { gapCount: 0, gapLocations: [] };
+  }
+  const gaps: GapLocation[] = [];
+  for (let i = 1; i < timeData.length; i++) {
+    const delta = timeData[i] - timeData[i - 1];
+    if (delta > GAP_THRESHOLD_SECONDS) {
+      gaps.push({ start_index: i - 1, end_index: i, duration_seconds: delta });
+    }
+  }
+  return { gapCount: gaps.length, gapLocations: gaps };
+}
+
+function downsample(
+  rawStreams: Record<string, RawStream>,
+  presentTypes: StreamType[],
+  bucketSeconds: number
+): Record<string, (number | number[] | boolean | null)[]> {
+  const timeData = rawStreams["time"]?.data as number[] | undefined;
+  if (!timeData || timeData.length === 0) {
+    return {};
+  }
+
+  const buckets: Map<number, Record<StreamType, (number | number[] | boolean | null)[]>> =
+    new Map();
+
+  for (let i = 0; i < timeData.length; i++) {
+    const t = timeData[i];
+    if (t === null || t === undefined) continue;
+    const bucketKey = Math.floor(t / bucketSeconds) * bucketSeconds;
+    if (!buckets.has(bucketKey)) {
+      buckets.set(bucketKey, {} as Record<StreamType, (number | number[] | boolean | null)[]>);
+    }
+    const bucket = buckets.get(bucketKey)!;
+    for (const type of presentTypes) {
+      if (!bucket[type]) bucket[type] = [];
+      const val = rawStreams[type]?.data?.[i] ?? null;
+      bucket[type].push(val);
+    }
+  }
+
+  const sortedKeys = [...buckets.keys()].sort((a, b) => a - b);
+  const result: Record<string, (number | number[] | boolean | null)[]> = {};
+
+  for (const type of presentTypes) {
+    result[type] = [];
+  }
+
+  for (const bucketKey of sortedKeys) {
+    const bucket = buckets.get(bucketKey)!;
+    for (const type of presentTypes) {
+      const vals = bucket[type] ?? [];
+      if (type === "moving") {
+        // Last-value for boolean streams
+        const lastVal = vals.filter((v) => v !== null).at(-1) ?? null;
+        result[type].push(lastVal);
+      } else if (type === "latlng") {
+        // Average latlng pairs
+        const validPairs = vals.filter(
+          (v): v is number[] => Array.isArray(v) && v.length === 2
+        );
+        if (validPairs.length === 0) {
+          result[type].push(null);
+        } else {
+          const avgLat = validPairs.reduce((s, p) => s + p[0], 0) / validPairs.length;
+          const avgLng = validPairs.reduce((s, p) => s + p[1], 0) / validPairs.length;
+          result[type].push([avgLat, avgLng]);
+        }
+      } else {
+        // Mean for numeric streams, preserving nulls
+        const numericVals = vals.filter((v): v is number => v !== null && typeof v === "number");
+        if (numericVals.length === 0) {
+          result[type].push(null);
+        } else {
+          result[type].push(numericVals.reduce((s, v) => s + v, 0) / numericVals.length);
+        }
+      }
+    }
+  }
+
+  return result;
 }

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -1,61 +1,191 @@
+import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { StravaClient } from "./client.js";
+import { handleStravaError } from "./errors.js";
+import { fetchActivityStreams } from "./streams.js";
+import type { StreamType } from "./types.js";
 
-// Stubs — each tool is implemented in its corresponding GitHub issue.
-// Issue #3: get_athlete_profile
-// Issue #4: get_recent_activities
-// Issue #5: get_activity_details
-// Issue #6: get_activity_streams
-// Issue #7: get_activity_zones
-// Issue #8: get_athlete_zones
-// Issue #9: get_athlete_stats
-export function registerStravaTools(server: McpServer, _client: StravaClient): void {
+function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+export function registerStravaTools(
+  server: McpServer,
+  client: StravaClient,
+  streamCache: KVNamespace
+): void {
+  // Issue #3 — get_athlete_profile
   server.tool(
     "get_athlete_profile",
-    "Stub — see issue #3",
+    "Returns the authenticated athlete's profile: name, location, weight, FTP, zones preference, and account info.",
     {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #3)" }] })
+    async () => {
+      try {
+        const res = await client.fetch("/athlete");
+        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        return ok(await res.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #4 — get_recent_activities
   server.tool(
     "get_recent_activities",
-    "Stub — see issue #4",
-    {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #4)" }] })
+    "Lists the athlete's activities. Filters: limit (default 30, max 200), before/after (epoch seconds), activity_type (e.g. 'Run').",
+    {
+      limit: z.number().int().min(1).max(200).default(30).describe("Max activities to return"),
+      before: z.number().int().optional().describe("Only return activities before this epoch timestamp"),
+      after: z.number().int().optional().describe("Only return activities after this epoch timestamp"),
+      activity_type: z.string().optional().describe("Filter by type, e.g. 'Run', 'Ride'"),
+    },
+    async ({ limit, before, after, activity_type }) => {
+      try {
+        const activities: unknown[] = [];
+        let page = 1;
+        while (activities.length < limit) {
+          const perPage = Math.min(200, limit - activities.length);
+          const params = new URLSearchParams({ page: String(page), per_page: String(perPage) });
+          if (before) params.set("before", String(before));
+          if (after) params.set("after", String(after));
+          const res = await client.fetch(`/athlete/activities?${params}`);
+          if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+          const page_data = (await res.json()) as unknown[];
+          if (page_data.length === 0) break;
+          activities.push(...page_data);
+          if (page_data.length < perPage) break;
+          page++;
+        }
+        const filtered = activity_type
+          ? activities.filter(
+              (a) =>
+                (a as Record<string, unknown>)["type"] === activity_type ||
+                (a as Record<string, unknown>)["sport_type"] === activity_type
+            )
+          : activities;
+        return ok(filtered.slice(0, limit));
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #5 — get_activity_details
   server.tool(
     "get_activity_details",
-    "Stub — see issue #5",
-    {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #5)" }] })
+    "Full breakdown for a single activity: laps, splits, best efforts, segment efforts, and all metadata.",
+    {
+      activity_id: z.number().int().describe("The Strava activity ID"),
+    },
+    async ({ activity_id }) => {
+      try {
+        const res = await client.fetch(`/activities/${activity_id}`);
+        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        return ok(await res.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #6 — get_activity_streams
   server.tool(
     "get_activity_streams",
-    "Stub — see issue #6",
-    {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #6)" }] })
+    "Raw per-second stream data for an activity. Returns time, distance, HR, pace, cadence, altitude, and more at full resolution. Thin pass-through — no smoothing or outlier removal.",
+    {
+      activity_id: z.number().int().describe("The Strava activity ID"),
+      stream_types: z
+        .array(
+          z.enum([
+            "time", "distance", "latlng", "altitude", "velocity_smooth",
+            "heartrate", "cadence", "watts", "temp", "moving", "grade_smooth",
+          ])
+        )
+        .optional()
+        .describe("Stream types to fetch. Defaults to time, distance, heartrate, velocity_smooth, altitude, cadence"),
+      resolution: z
+        .enum(["low", "medium", "high", "all"])
+        .optional()
+        .describe("Data resolution. Default 'all' for maximum fidelity"),
+      downsample_to_seconds: z
+        .number()
+        .int()
+        .min(2)
+        .optional()
+        .describe("Transport optimisation only: average into N-second buckets. Not for analytical use."),
+      format: z
+        .enum(["arrays", "rows"])
+        .optional()
+        .describe("'arrays' (default, Strava native) or 'rows' (one object per second)"),
+    },
+    async ({ activity_id, stream_types, resolution, downsample_to_seconds, format }) => {
+      try {
+        const result = await fetchActivityStreams(client, streamCache, {
+          activityId: activity_id,
+          streamTypes: stream_types as StreamType[] | undefined,
+          resolution: resolution as "low" | "medium" | "high" | "all" | undefined,
+          downsampleToSeconds: downsample_to_seconds,
+          format: format as "arrays" | "rows" | undefined,
+        });
+        return ok(result);
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #7 — get_activity_zones
   server.tool(
     "get_activity_zones",
-    "Stub — see issue #7",
-    {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #7)" }] })
+    "HR and power zone distribution for an activity, as reported by Strava. No re-bucketing.",
+    {
+      activity_id: z.number().int().describe("The Strava activity ID"),
+    },
+    async ({ activity_id }) => {
+      try {
+        const res = await client.fetch(`/activities/${activity_id}/zones`);
+        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        return ok(await res.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #8 — get_athlete_zones
   server.tool(
     "get_athlete_zones",
-    "Stub — see issue #8",
+    "The athlete's configured HR and power zone thresholds. Use alongside get_activity_zones to interpret zone distribution.",
     {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #8)" }] })
+    async () => {
+      try {
+        const res = await client.fetch("/athlete/zones");
+        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        return ok(await res.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 
+  // Issue #9 — get_athlete_stats
   server.tool(
     "get_athlete_stats",
-    "Stub — see issue #9",
+    "Recent (last 4 weeks), YTD, and all-time totals by sport (run, ride, swim): count, distance, time, elevation.",
     {},
-    async () => ({ content: [{ type: "text" as const, text: "Not yet implemented (issue #9)" }] })
+    async () => {
+      try {
+        // Need athlete ID first
+        const athleteRes = await client.fetch("/athlete");
+        if (!athleteRes.ok) throw Object.assign(new Error(athleteRes.statusText), { status: athleteRes.status });
+        const athlete = (await athleteRes.json()) as { id: number };
+        const statsRes = await client.fetch(`/athletes/${athlete.id}/stats`);
+        if (!statsRes.ok) throw Object.assign(new Error(statsRes.statusText), { status: statsRes.status });
+        return ok(await statsRes.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
   );
 }

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchActivityStreams } from "../src/strava/streams.js";
+import type { StravaClient } from "../src/strava/client.js";
+
+function makeKv(initial: Record<string, string> = {}): KVNamespace {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => { store.set(key, value); }),
+    delete: vi.fn(async (key: string) => { store.delete(key); }),
+    list: vi.fn(async () => ({ keys: [], list_complete: true, cursor: "" })),
+    getWithMetadata: vi.fn(async () => ({ value: null, metadata: null })),
+  } as unknown as KVNamespace;
+}
+
+function makeClient(streamsBody: unknown): StravaClient {
+  return {
+    fetch: vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(streamsBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    ),
+    lastRateLimitInfo: null,
+  } as unknown as StravaClient;
+}
+
+// Minimal stream fixture: 10 seconds of data
+function makeStreams(overrides: Record<string, number[]> = {}) {
+  const time = overrides.time ?? [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const distance = overrides.distance ?? [0, 3, 6, 9, 12, 15, 18, 21, 24, 27];
+  const heartrate = overrides.heartrate ?? [140, 142, 143, 145, 144, 146, 145, 147, 148, 149];
+  return [
+    { type: "time", data: time, series_type: "time", original_size: time.length, resolution: "high" },
+    { type: "distance", data: distance, series_type: "time", original_size: distance.length, resolution: "high" },
+    { type: "heartrate", data: heartrate, series_type: "time", original_size: heartrate.length, resolution: "high" },
+  ];
+}
+
+describe("fetchActivityStreams", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetches and returns streams in arrays format", async () => {
+    const client = makeClient(makeStreams());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 123,
+      streamTypes: ["time", "distance", "heartrate"],
+    });
+    expect(result.metadata.stream_types_present).toContain("time");
+    expect(result.metadata.stream_types_missing).not.toContain("time");
+    expect(result.metadata.gap_count).toBe(0);
+    expect((result.data as Record<string, unknown[]>)["time"]).toHaveLength(10);
+  });
+
+  it("converts to rows format when requested", async () => {
+    const client = makeClient(makeStreams());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 123,
+      streamTypes: ["time", "heartrate"],
+      format: "rows",
+    });
+    const rows = result.data as Record<string, unknown>[];
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows[0]).toHaveProperty("time");
+    expect(rows[0]).toHaveProperty("heartrate");
+    expect(rows).toHaveLength(10);
+  });
+
+  it("lists missing stream types in metadata", async () => {
+    const client = makeClient(makeStreams()); // only has time, distance, heartrate
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 123,
+      streamTypes: ["time", "watts", "cadence"], // watts and cadence not in fixture
+    });
+    expect(result.metadata.stream_types_missing).toContain("watts");
+    expect(result.metadata.stream_types_missing).toContain("cadence");
+    expect(result.metadata.stream_types_present).toContain("time");
+  });
+
+  it("uses cache on second call", async () => {
+    const fixture = makeStreams();
+    const client = makeClient(fixture);
+    const kv = makeKv();
+
+    await fetchActivityStreams(client, kv, { activityId: 123 });
+    expect(kv.put).toHaveBeenCalledTimes(1);
+
+    // Second call — should hit cache
+    const cachedValue = (kv.put as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const kv2 = makeKv({ "streams:123:all": cachedValue });
+    const client2 = makeClient(fixture);
+    await fetchActivityStreams(client2, kv2, { activityId: 123 });
+    expect((client2.fetch as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it("detects gaps in the time stream", async () => {
+    // Gap between index 4 and 5: 0,1,2,3,4 -> 15 (11-second gap)
+    const streams = makeStreams({ time: [0, 1, 2, 3, 4, 15, 16, 17, 18, 19] });
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 456,
+      streamTypes: ["time"],
+    });
+    expect(result.metadata.gap_count).toBe(1);
+    expect(result.metadata.gap_locations[0]).toMatchObject({
+      start_index: 4,
+      end_index: 5,
+      duration_seconds: 11,
+    });
+  });
+
+  it("downsamples streams into N-second buckets", async () => {
+    // 10 data points at 1s each, downsample to 5s => 2 buckets
+    const client = makeClient(makeStreams());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 789,
+      streamTypes: ["time", "heartrate"],
+      downsampleToSeconds: 5,
+    });
+    const timeArr = (result.data as Record<string, unknown[]>)["time"];
+    expect(timeArr.length).toBe(2); // seconds 0-4 and 5-9
+  });
+
+  it("simulates a large activity (14400 points) without error", async () => {
+    const n = 14400;
+    const time = Array.from({ length: n }, (_, i) => i);
+    const hr = Array.from({ length: n }, () => 150);
+    const streams = [
+      { type: "time", data: time, series_type: "time", original_size: n, resolution: "high" },
+      { type: "heartrate", data: hr, series_type: "time", original_size: n, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 999,
+      streamTypes: ["time", "heartrate"],
+    });
+    expect(result.metadata.original_size).toBe(n);
+    expect((result.data as Record<string, unknown[]>)["time"]).toHaveLength(n);
+  });
+
+  it("preserves nulls in downsampled output", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2, 3, 4], series_type: "time", original_size: 5, resolution: "high" },
+      { type: "heartrate", data: [140, null, null, null, 150], series_type: "time", original_size: 5, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 101,
+      streamTypes: ["time", "heartrate"],
+      downsampleToSeconds: 3,
+    });
+    // Bucket 0-2: heartrate has [140, null, null] -> avg of [140] = 140
+    // Bucket 3-4: heartrate has [null, 150] -> avg of [150] = 150
+    const hrArr = (result.data as Record<string, number[]>)["heartrate"];
+    expect(hrArr[0]).toBe(140);
+    expect(hrArr[1]).toBe(150);
+  });
+});


### PR DESCRIPTION
## Summary

Implements all Phase 1 Strava tools and the streams module.

**New tools** (all in `src/strava/tools.ts`):
- `get_athlete_profile` — `GET /athlete`
- `get_recent_activities` — paginated list with type filter
- `get_activity_details` — full activity with laps/splits/efforts
- `get_activity_streams` — thin pass-through, STREAM_CACHE KV, gap detection, downsampling, arrays/rows format
- `get_activity_zones` — `GET /activities/{id}/zones`
- `get_athlete_zones` — `GET /athlete/zones`
- `get_athlete_stats` — `GET /athletes/{id}/stats`

All tools use `handleStravaError` for consistent error responses.

**`src/strava/streams.ts`**: caches full-res streams (30-day KV TTL), gap detection (>5s), N-second downsampling (mean/last-value), null preservation.

**32/32 tests pass**, typecheck and lint clean.

Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)