### PR TITLE
[#10] Worker-level rate limiting (60 req/min per IP)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,15 @@ import { StravaClient } from "./strava/client.js";
 import { registerStravaTools } from "./strava/tools.js";
 import type { Env } from "./types.js";
 
+function rateLimitedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: { code: "RATE_LIMITED", message: "Too many requests. Slow down and try again." },
+    }),
+    { status: 429, headers: { "Content-Type": "application/json" } }
+  );
+}
+
 function buildMcpServer(env: Env): McpServer {
   const server = new McpServer({
     name: "strava-mcp",
@@ -20,6 +29,13 @@ export default {
     if (!validateBearerToken(request, env.MCP_AUTH_TOKEN)) {
       return unauthorizedResponse();
     }
+
+    const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
+    const { success } = await env.IP_RATE_LIMITER.limit({ key: ip });
+    if (!success) {
+      return rateLimitedResponse();
+    }
+
     const server = buildMcpServer(env);
     const handler = createMcpHandler(server, { route: "/mcp" });
     return handler(request, env, ctx);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Env {
   TOKEN_CACHE: KVNamespace;
   STREAM_CACHE: KVNamespace;
+  IP_RATE_LIMITER: RateLimit;
   MCP_AUTH_TOKEN: string;
   STRAVA_CLIENT_ID: string;
   STRAVA_CLIENT_SECRET: string;

--- a/test/strava-client.test.ts
+++ b/test/strava-client.test.ts
@@ -21,6 +21,7 @@ function makeEnv(kv: KVNamespace): Env {
   return {
     TOKEN_CACHE: kv,
     STREAM_CACHE: {} as KVNamespace,
+    IP_RATE_LIMITER: {} as RateLimit,
     MCP_AUTH_TOKEN: "test-token",
     STRAVA_CLIENT_ID: "client123",
     STRAVA_CLIENT_SECRET: "secret456",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,19 @@
     }
   ],
 
-  // Observability
+  // Worker-level rate limiting: 60 req/min per IP
+  // This is in addition to Strava's own rate limits.
+  "ratelimits": [
+    {
+      "name": "IP_RATE_LIMITER",
+      "namespace_id": 1001,
+      "simple": {
+        "limit": 60,
+        "period": 60
+      }
+    }
+  ],
+
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
Adds Cloudflare Rate Limiting binding to `wrangler.jsonc` (60 req/min per IP). Returns 429 JSON error when exceeded. Updates Env interface and fetch handler. Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)