### PR TITLE
[#12] First-deploy walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,92 +14,99 @@ The one exception to "no server-side processing" is `downsample_to_seconds` on s
 
 ---
 
-## Strava app setup
+## First deploy — complete walkthrough
 
-### Step 1 — Register a Strava API app
+Follow these steps in order to go from zero to a working Claude connector.
+
+### 1. Prerequisites
+
+- Node.js 20+ (`node --version`)
+- pnpm (`npm install -g pnpm`)
+- Cloudflare account (free tier is fine): [dash.cloudflare.com/sign-up](https://dash.cloudflare.com/sign-up)
+- GitHub CLI authenticated: `gh auth status`
+
+### 2. Clone and install
+
+```bash
+git clone https://github.com/mike-keefe/strava-mcp
+cd strava-mcp
+pnpm install
+```
+
+### 3. Register a Strava API app
 
 1. Go to [https://www.strava.com/settings/api](https://www.strava.com/settings/api) and create an app.
 2. Fill in any name and website (e.g. `http://localhost`).
 3. Set **Authorization Callback Domain** to `localhost`.
 4. Submit. Note your **Client ID** and **Client Secret** from the app page.
 
-The exact OAuth scopes this server requests: **`read,activity:read_all,profile:read_all`**
+The OAuth scopes this server uses: **`read,activity:read_all,profile:read_all`** — read-only, no write scopes ever.
 
-`activity:write`, `profile:write`, and all other write scopes are never requested — this MCP is read-only by design.
-
-### Step 2 — Get your refresh token
-
-Add your Client ID and Secret to `.dev.vars`, then run:
+### 4. Get your Strava refresh token
 
 ```bash
+cp .dev.vars.example .dev.vars
+# Edit .dev.vars — add your STRAVA_CLIENT_ID and STRAVA_CLIENT_SECRET
+
 pnpm get-refresh-token
 ```
 
-This opens Strava in your browser, asks you to authorise the app, captures the callback, and prints your refresh token to the terminal. The refresh token is long-lived (doesn't expire unless you revoke it) — you only need to run this once.
+This opens Strava in your browser, asks you to authorise the app, and prints your refresh token to the terminal. Copy it into `.dev.vars` as `STRAVA_REFRESH_TOKEN`. The refresh token is long-lived — you only need to do this once.
 
-Copy the printed `STRAVA_REFRESH_TOKEN` into your `.dev.vars` file.
+### 5. Log in to Cloudflare and create KV namespaces
 
-### Step 3 — Set Cloudflare Worker secrets (after deploying)
+> **Skip this step** if you already have `wrangler.jsonc` populated with real KV IDs (done during initial project setup).
 
 ```bash
+npx wrangler login
+
+npx wrangler kv namespace create TOKEN_CACHE
+npx wrangler kv namespace create STREAM_CACHE
+# For local dev, also create preview namespaces:
+npx wrangler kv namespace create TOKEN_CACHE --preview
+npx wrangler kv namespace create STREAM_CACHE --preview
+```
+
+Copy the printed IDs into the `kv_namespaces` section of `wrangler.jsonc`.
+
+### 6. Deploy
+
+```bash
+pnpm deploy
+```
+
+The Worker URL will be printed at the end: `https://strava-mcp.<your-subdomain>.workers.dev`
+
+### 7. Set Worker secrets
+
+```bash
+npx wrangler secret put MCP_AUTH_TOKEN       # the token from your .dev.vars
 npx wrangler secret put STRAVA_CLIENT_ID
 npx wrangler secret put STRAVA_CLIENT_SECRET
 npx wrangler secret put STRAVA_REFRESH_TOKEN
 ```
 
-Paste each value when prompted. These secrets are stored encrypted by Cloudflare and never appear in your code or wrangler.jsonc.
+Paste each value when prompted.
+
+### 8. Add to Claude
+
+1. In Claude: **Settings → Connectors → Add custom connector**
+2. URL: `https://strava-mcp.<your-subdomain>.workers.dev/mcp`
+3. Add header: `Authorization: Bearer <your MCP_AUTH_TOKEN>`
+4. Save and test with: *"what's my latest activity?"*
 
 ---
 
-## Setup (local dev)
+## Local development
 
 ```bash
-git clone https://github.com/mike-keefe/strava-mcp
-cd strava-mcp
-pnpm install
-
-# Create Cloudflare KV namespaces (requires wrangler login first)
-npx wrangler login
-npx wrangler kv namespace create TOKEN_CACHE
-npx wrangler kv namespace create STREAM_CACHE
-# Copy the IDs printed above into wrangler.jsonc
-
-# Copy and fill in dev secrets
 cp .dev.vars.example .dev.vars
-# Edit .dev.vars with your values
+# Fill in all four values in .dev.vars
 
 pnpm dev
 ```
 
----
-
-## Deployment
-
-```bash
-# One-time: login and create KV namespaces (see Setup above)
-npx wrangler login
-
-# Set secrets (run each and paste the value when prompted)
-npx wrangler secret put MCP_AUTH_TOKEN      # use the token printed during initial setup
-npx wrangler secret put STRAVA_CLIENT_ID
-npx wrangler secret put STRAVA_CLIENT_SECRET
-npx wrangler secret put STRAVA_REFRESH_TOKEN
-
-# Deploy
-pnpm deploy
-```
-
-See **issue #12** for the full first-deploy walkthrough.
-
----
-
-## Adding to Claude
-
-1. Deploy (above).
-2. In Claude: **Settings → Connectors → Add custom connector**.
-3. Enter your deployed Worker URL (e.g. `https://strava-mcp.your-subdomain.workers.dev/mcp`).
-4. Add a header: `Authorization: Bearer <your MCP_AUTH_TOKEN>`.
-5. Test with: *"what's my latest activity?"*
+The Worker runs locally at `http://localhost:8787`. Use the same `Authorization: Bearer` header to test.
 
 ---
 
@@ -123,20 +130,32 @@ See **issue #12** for the full first-deploy walkthrough.
 | `list_gear` | Bikes and shoes with mileage | #19 |
 | `get_activity_laps` | Manually-pressed laps for an activity | #20 |
 
-*All tools marked with an issue number are stubs pending that issue.*
-
 ---
 
 ## Development scripts
 
 ```bash
-pnpm dev        # local dev server (wrangler dev)
-pnpm deploy     # deploy to Cloudflare
-pnpm test       # run tests in watch mode
-pnpm test:run   # run tests once
-pnpm lint       # ESLint
-pnpm lint:fix   # ESLint with autofix
-pnpm typecheck  # TypeScript type checking
+pnpm dev               # local dev server (wrangler dev)
+pnpm deploy            # deploy to Cloudflare
+pnpm test              # run tests in watch mode
+pnpm test:run          # run tests once
+pnpm lint              # ESLint
+pnpm lint:fix          # ESLint with autofix
+pnpm typecheck         # TypeScript type checking
 pnpm tail              # stream live Worker logs (wrangler tail)
 pnpm get-refresh-token # run the Strava OAuth flow to get a refresh token
 ```
+
+---
+
+## Design philosophy (for contributors)
+
+This MCP is intentionally a thin data layer. Its job is to fetch and return Strava data faithfully — nothing more. All analysis (smoothing, outlier removal, drift calculation, zone analysis, comparisons across activities) happens in conversation with Claude.
+
+Concretely:
+- Streams are returned raw. No `smooth` parameter, no `clean_outliers`, no `moving_only` filter.
+- The only allowed server-side transformation is `downsample_to_seconds` (transport optimisation only).
+- No "analyse_run" or similar derived-metric tools. Those belong in conversation.
+- Gap metadata is informational — the MCP never fills or interpolates gaps.
+
+If a future issue suggests adding analytical opinions to the MCP, push back and ask Mike to confirm.


### PR DESCRIPTION
Complete end-to-end README walkthrough covering: Strava app registration, refresh token script, KV namespace creation, deploy, secret configuration, and Claude connector setup. Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)