### PR TITLE
[#29] OAuth 2.0 server, multi-user Strava auth, and tool test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # strava-mcp
 
-A personal, single-user MCP server exposing Strava data to Claude for detailed running analysis. Read-only. Thin data layer — no analysis logic. Deployed to Cloudflare Workers.
+An MCP server exposing Strava data to Claude for detailed running analysis. Read-only. Thin data layer — no analysis logic. Deployed to Cloudflare Workers. Supports multiple users — each person connects their own Strava account via OAuth.
 
 ---
 
@@ -37,12 +37,15 @@ pnpm install
 
 1. Go to [https://www.strava.com/settings/api](https://www.strava.com/settings/api) and create an app.
 2. Fill in any name and website (e.g. `http://localhost`).
-3. Set **Authorization Callback Domain** to `localhost`.
+3. Set **Authorization Callback Domain** to your Worker domain: `strava-mcp.<your-subdomain>.workers.dev`
+   - You can update this after deploy once you know the URL; use `localhost` for now if you haven't deployed yet.
 4. Submit. Note your **Client ID** and **Client Secret** from the app page.
 
 The OAuth scopes this server uses: **`read,activity:read_all,profile:read_all`** — read-only, no write scopes ever.
 
-### 4. Get your Strava refresh token
+### 4. Get your Strava refresh token (optional — for static admin access only)
+
+This step is only needed if you want to use the server with a static `MCP_AUTH_TOKEN` Bearer header (e.g. for local testing or programmatic access). Users connecting through Claude's OAuth flow skip this entirely — they authorize directly via Strava in the browser.
 
 ```bash
 cp .dev.vars.example .dev.vars
@@ -51,7 +54,7 @@ cp .dev.vars.example .dev.vars
 pnpm get-refresh-token
 ```
 
-This opens Strava in your browser, asks you to authorise the app, and prints your refresh token to the terminal. Copy it into `.dev.vars` as `STRAVA_REFRESH_TOKEN`. The refresh token is long-lived — you only need to do this once.
+This opens Strava in your browser and prints your refresh token to the terminal. Copy it into `.dev.vars` as `STRAVA_REFRESH_TOKEN`.
 
 ### 5. Log in to Cloudflare and create KV namespaces
 
@@ -88,12 +91,22 @@ npx wrangler secret put STRAVA_REFRESH_TOKEN
 
 Paste each value when prompted.
 
-### 8. Add to Claude
+### 8. Update Strava app callback domain
+
+If you set `localhost` as the callback domain in step 3, update it now:
+
+1. Go to [https://www.strava.com/settings/api](https://www.strava.com/settings/api)
+2. Set **Authorization Callback Domain** to `strava-mcp.<your-subdomain>.workers.dev`
+3. Save.
+
+### 9. Add to Claude
 
 1. In Claude: **Settings → Connectors → Add custom connector**
 2. URL: `https://strava-mcp.<your-subdomain>.workers.dev/mcp`
-3. Add header: `Authorization: Bearer <your MCP_AUTH_TOKEN>`
-4. Save and test with: *"what's my latest activity?"*
+3. Click **Connect** — Claude will open a browser window for you to authorise with Strava.
+4. After Strava approval, test with: *"what's my latest activity?"*
+
+> **Note:** Anyone with the URL can connect their own Strava account by following the same OAuth flow. Each user's Strava tokens are stored separately.
 
 ---
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,26 +8,41 @@ function timingSafeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
+export function extractBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  return authHeader.slice(7);
+}
+
+export function isStaticTokenValid(token: string, expectedToken: string): boolean {
+  if (token.length !== expectedToken.length) return false;
+  return timingSafeEqual(token, expectedToken);
+}
+
+// Kept for existing tests — composes the two functions above
 export function validateBearerToken(
   request: Request,
   expectedToken: string
 ): boolean {
-  const authHeader = request.headers.get("Authorization");
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return false;
-  }
-  const token = authHeader.slice(7);
-  if (token.length !== expectedToken.length) {
-    return false;
-  }
-  return timingSafeEqual(token, expectedToken);
+  const token = extractBearerToken(request);
+  if (!token) return false;
+  return isStaticTokenValid(token, expectedToken);
 }
 
-export function unauthorizedResponse(): Response {
+export function unauthorizedResponse(origin?: string): Response {
+  const wwwAuth = origin
+    ? `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`
+    : "Bearer";
   return new Response(
     JSON.stringify({
       error: { code: "UNAUTHORIZED", message: "Invalid or missing bearer token" },
     }),
-    { status: 401, headers: { "Content-Type": "application/json" } }
+    {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+        "WWW-Authenticate": wwwAuth,
+      },
+    }
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,9 @@ function rateLimitedResponse(): Response {
   );
 }
 
-function buildMcpServer(env: Env): McpServer {
-  const server = new McpServer({
-    name: "strava-mcp",
-    version: "0.1.0",
-  });
-  const client = new StravaClient(env);
+function buildMcpServer(env: Env, userOAuthToken?: string): McpServer {
+  const server = new McpServer({ name: "strava-mcp", version: "0.1.0" });
+  const client = new StravaClient(env, userOAuthToken);
   registerStravaTools(server, client, env.STREAM_CACHE);
   return server;
 }
@@ -29,18 +26,17 @@ export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
-    // OAuth endpoints are unauthenticated — must be handled before the token check
+    // OAuth endpoints are unauthenticated — handle before the token check
     if (isOAuthPath(url.pathname)) {
       return handleOAuth(request, env);
     }
 
-    // Accept static admin token (fast path) OR a KV-stored OAuth access token
+    // Accept static admin token (fast, sync) OR a KV-stored OAuth access token
     const token = extractBearerToken(request);
-    const isValid =
-      token !== null &&
-      (isStaticTokenValid(token, env.MCP_AUTH_TOKEN) ||
-        (await isValidOAuthToken(token, env)));
-    if (!isValid) {
+    const isStaticAuth = token !== null && isStaticTokenValid(token, env.MCP_AUTH_TOKEN);
+    const isOAuthAuth = !isStaticAuth && token !== null && (await isValidOAuthToken(token, env));
+
+    if (!isStaticAuth && !isOAuthAuth) {
       return unauthorizedResponse(url.origin);
     }
 
@@ -50,7 +46,8 @@ export default {
       return rateLimitedResponse();
     }
 
-    const server = buildMcpServer(env);
+    // Static token uses the shared STRAVA_REFRESH_TOKEN; OAuth tokens are per-user
+    const server = buildMcpServer(env, isOAuthAuth ? token! : undefined);
     const handler = createMcpHandler(server, { route: "/mcp" });
     return handler(request, env, ctx);
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpHandler } from "agents/mcp";
-import { validateBearerToken, unauthorizedResponse } from "./auth.js";
+import { extractBearerToken, isStaticTokenValid, unauthorizedResponse } from "./auth.js";
+import { isOAuthPath, handleOAuth, isValidOAuthToken } from "./oauth.js";
 import { StravaClient } from "./strava/client.js";
 import { registerStravaTools } from "./strava/tools.js";
 import type { Env } from "./types.js";
@@ -26,8 +27,21 @@ function buildMcpServer(env: Env): McpServer {
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    if (!validateBearerToken(request, env.MCP_AUTH_TOKEN)) {
-      return unauthorizedResponse();
+    const url = new URL(request.url);
+
+    // OAuth endpoints are unauthenticated — must be handled before the token check
+    if (isOAuthPath(url.pathname)) {
+      return handleOAuth(request, env);
+    }
+
+    // Accept static admin token (fast path) OR a KV-stored OAuth access token
+    const token = extractBearerToken(request);
+    const isValid =
+      token !== null &&
+      (isStaticTokenValid(token, env.MCP_AUTH_TOKEN) ||
+        (await isValidOAuthToken(token, env)));
+    if (!isValid) {
+      return unauthorizedResponse(url.origin);
     }
 
     const ip = request.headers.get("cf-connecting-ip") ?? "unknown";

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -7,10 +7,20 @@ const KV = {
   code: (c: string) => `oauth:code:${c}`,
   token: (t: string) => `oauth:token:${t}`,
   client: (id: string) => `oauth:client:${id}`,
+  session: (s: string) => `oauth:session:${s}`,
 };
 
+const SESSION_TTL_SECONDS = 600; // 10 min to complete Strava auth
 const CODE_TTL_SECONDS = 600; // 10 minutes
 const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
+
+const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
+const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
+const STRAVA_SCOPES = "read,activity:read_all,profile:read_all";
+
+// Shared with StravaClient — per-user Strava access token cache key
+export const stravaTokenCacheKey = (oauthToken: string) =>
+  `strava:cached:${oauthToken}`;
 
 // ---------------------------------------------------------------------------
 // Routing
@@ -37,9 +47,11 @@ export async function handleOAuth(request: Request, env: Env): Promise<Response>
   if (pathname === "/oauth/register" && request.method === "POST") {
     return dynamicRegistration(request, env, origin);
   }
-  if (pathname === "/oauth/authorize") {
-    if (request.method === "GET") return authorizeGet(request, env, origin);
-    if (request.method === "POST") return authorizePost(request, env, origin);
+  if (pathname === "/oauth/authorize" && request.method === "GET") {
+    return authorizeGet(request, env, origin);
+  }
+  if (pathname === "/oauth/strava-callback" && request.method === "GET") {
+    return stravaCallback(request, env, origin);
   }
   if (pathname === "/oauth/token" && request.method === "POST") {
     return tokenEndpoint(request, env, origin);
@@ -68,9 +80,9 @@ function authServerMetadata(origin: string): Response {
     registration_endpoint: `${origin}/oauth/register`,
     scopes_supported: ["mcp"],
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code", "client_credentials"],
+    grant_types_supported: ["authorization_code"],
     code_challenge_methods_supported: ["S256"],
-    token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+    token_endpoint_auth_methods_supported: ["none"],
   });
 }
 
@@ -111,13 +123,9 @@ async function dynamicRegistration(
   }
 
   const clientId = generateToken();
-  // Public clients (PKCE) don't need a client_secret
-  const isPublic = body["token_endpoint_auth_method"] === "none";
-  const clientSecret = isPublic ? null : generateToken();
-
   const record: ClientRecord = {
     client_id: clientId,
-    client_secret: clientSecret,
+    client_secret: null,
     redirect_uris: redirectUris as string[],
     client_name: typeof body["client_name"] === "string" ? body["client_name"] : undefined,
   };
@@ -127,27 +135,25 @@ async function dynamicRegistration(
   return json(
     {
       client_id: clientId,
-      ...(clientSecret ? { client_secret: clientSecret } : {}),
       redirect_uris: redirectUris,
       grant_types: ["authorization_code"],
       response_types: ["code"],
-      token_endpoint_auth_method: isPublic ? "none" : "client_secret_post",
+      token_endpoint_auth_method: "none",
     },
     201
   );
 }
 
 // ---------------------------------------------------------------------------
-// Authorization endpoint
+// Authorization endpoint — redirects to Strava
 // ---------------------------------------------------------------------------
 
-interface AuthParams {
+interface SessionRecord {
   clientId: string;
   redirectUri: string;
   state: string;
   codeChallenge: string;
   codeChallengeMethod: string;
-  scope?: string;
 }
 
 async function authorizeGet(
@@ -172,7 +178,6 @@ async function authorizeGet(
     return oauthError("invalid_request", "Missing required parameters");
   }
 
-  // Validate registered client
   const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
   if (!clientRaw) {
     return oauthError("invalid_client", "Unknown client_id");
@@ -182,66 +187,110 @@ async function authorizeGet(
     return oauthError("invalid_request", "redirect_uri not registered for this client");
   }
 
-  const clientName = client.client_name ?? clientId;
-
-  return new Response(authorizePage({ clientName, clientId, redirectUri, state, codeChallenge, codeChallengeMethod, origin }), {
-    headers: { "Content-Type": "text/html;charset=UTF-8" },
+  // Save OAuth session so the Strava callback can complete the flow
+  const sessionId = generateToken();
+  const session: SessionRecord = { clientId, redirectUri, state, codeChallenge, codeChallengeMethod };
+  await env.TOKEN_CACHE.put(KV.session(sessionId), JSON.stringify(session), {
+    expirationTtl: SESSION_TTL_SECONDS,
   });
+
+  // Redirect user to Strava's consent screen
+  const stravaUrl = new URL(STRAVA_AUTH_URL);
+  stravaUrl.searchParams.set("client_id", env.STRAVA_CLIENT_ID);
+  stravaUrl.searchParams.set("redirect_uri", `${origin}/oauth/strava-callback`);
+  stravaUrl.searchParams.set("response_type", "code");
+  stravaUrl.searchParams.set("approval_prompt", "force");
+  stravaUrl.searchParams.set("scope", STRAVA_SCOPES);
+  stravaUrl.searchParams.set("state", sessionId);
+  return Response.redirect(stravaUrl.toString(), 302);
 }
 
-async function authorizePost(
+// ---------------------------------------------------------------------------
+// Strava callback — completes the OAuth flow
+// ---------------------------------------------------------------------------
+
+interface StravaTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+}
+
+async function stravaCallback(
   request: Request,
   env: Env,
-  origin: string
+  _origin: string
 ): Promise<Response> {
-  let body: URLSearchParams;
-  try {
-    body = new URLSearchParams(await request.text());
-  } catch {
-    return oauthError("invalid_request", "Invalid form body");
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const sessionId = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (!sessionId) {
+    return new Response("Missing state parameter", { status: 400 });
   }
 
-  const approved = body.get("approved") === "true";
-  const clientId = body.get("client_id") ?? "";
-  const redirectUri = body.get("redirect_uri") ?? "";
-  const state = body.get("state") ?? "";
-  const codeChallenge = body.get("code_challenge") ?? "";
-  const codeChallengeMethod = body.get("code_challenge_method") ?? "S256";
+  const sessionRaw = await env.TOKEN_CACHE.get(KV.session(sessionId));
+  if (!sessionRaw) {
+    return new Response("Session expired or invalid. Please start the authorization flow again.", {
+      status: 400,
+    });
+  }
+  const session = JSON.parse(sessionRaw) as SessionRecord;
+  await env.TOKEN_CACHE.delete(KV.session(sessionId));
 
-  if (!approved) {
-    const denied = new URL(redirectUri);
+  if (error) {
+    const denied = new URL(session.redirectUri);
     denied.searchParams.set("error", "access_denied");
-    if (state) denied.searchParams.set("state", state);
+    if (session.state) denied.searchParams.set("state", session.state);
     return Response.redirect(denied.toString(), 302);
   }
 
-  // Validate registered client again
-  const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
-  if (!clientRaw) {
-    return oauthError("invalid_client", "Unknown client_id");
-  }
-  const client = JSON.parse(clientRaw) as ClientRecord;
-  if (!client.redirect_uris.includes(redirectUri)) {
-    return oauthError("invalid_request", "redirect_uri mismatch");
+  if (!code) {
+    return new Response("Missing code parameter", { status: 400 });
   }
 
-  const code = generateToken();
-  const codeRecord: AuthParams & { used: boolean } = {
-    clientId,
-    redirectUri,
-    state,
-    codeChallenge,
-    codeChallengeMethod,
-    used: false,
-  };
-  await env.TOKEN_CACHE.put(KV.code(code), JSON.stringify(codeRecord), {
-    expirationTtl: CODE_TTL_SECONDS,
+  // Exchange Strava authorization code for tokens
+  const tokenRes = await fetch(STRAVA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_id: env.STRAVA_CLIENT_ID,
+      client_secret: env.STRAVA_CLIENT_SECRET,
+      code,
+      grant_type: "authorization_code",
+    }),
   });
 
-  const redirectUrl = new URL(redirectUri);
-  redirectUrl.searchParams.set("code", code);
-  if (state) redirectUrl.searchParams.set("state", state);
-  void origin;
+  if (!tokenRes.ok) {
+    return new Response(
+      `Failed to exchange Strava authorization code (${tokenRes.status})`,
+      { status: 502 }
+    );
+  }
+
+  const stravaTokens = (await tokenRes.json()) as StravaTokenResponse;
+
+  // Issue our own authorization code, embedding the user's Strava refresh token
+  const ourCode = generateToken();
+  await env.TOKEN_CACHE.put(
+    KV.code(ourCode),
+    JSON.stringify({
+      clientId: session.clientId,
+      redirectUri: session.redirectUri,
+      state: session.state,
+      codeChallenge: session.codeChallenge,
+      codeChallengeMethod: session.codeChallengeMethod,
+      stravaRefreshToken: stravaTokens.refresh_token,
+      stravaAccessToken: stravaTokens.access_token,
+      stravaTokenExpiresAt: stravaTokens.expires_at,
+      used: false,
+    }),
+    { expirationTtl: CODE_TTL_SECONDS }
+  );
+
+  const redirectUrl = new URL(session.redirectUri);
+  redirectUrl.searchParams.set("code", ourCode);
+  if (session.state) redirectUrl.searchParams.set("state", session.state);
   return Response.redirect(redirectUrl.toString(), 302);
 }
 
@@ -256,21 +305,28 @@ async function tokenEndpoint(
 ): Promise<Response> {
   let body: URLSearchParams;
   try {
-    const text = await request.text();
-    body = new URLSearchParams(text);
+    body = new URLSearchParams(await request.text());
   } catch {
     return oauthError("invalid_request", "Invalid request body");
   }
 
   const grantType = body.get("grant_type");
-
   if (grantType === "authorization_code") {
     return handleAuthCodeGrant(body, env, origin);
   }
-  if (grantType === "client_credentials") {
-    return handleClientCredentialsGrant(body, env, origin);
-  }
   return oauthError("unsupported_grant_type", `Unsupported grant_type: ${grantType}`);
+}
+
+interface CodeRecord {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  stravaRefreshToken: string;
+  stravaAccessToken: string;
+  stravaTokenExpiresAt: number;
+  used: boolean;
 }
 
 async function handleAuthCodeGrant(
@@ -292,7 +348,7 @@ async function handleAuthCodeGrant(
     return oauthError("invalid_grant", "Authorization code not found or expired");
   }
 
-  const codeRecord = JSON.parse(codeRaw) as AuthParams & { used: boolean };
+  const codeRecord = JSON.parse(codeRaw) as CodeRecord;
 
   if (codeRecord.used) {
     return oauthError("invalid_grant", "Authorization code already used");
@@ -307,53 +363,34 @@ async function handleAuthCodeGrant(
     return oauthError("invalid_grant", "PKCE verification failed");
   }
 
-  // Mark code as used and delete it
   await env.TOKEN_CACHE.delete(KV.code(code));
 
   const accessToken = generateToken();
+
+  // Store our token record with the user's Strava refresh token
   await env.TOKEN_CACHE.put(
     KV.token(accessToken),
-    JSON.stringify({ clientId, issuedAt: Date.now() }),
+    JSON.stringify({
+      clientId,
+      issuedAt: Date.now(),
+      stravaRefreshToken: codeRecord.stravaRefreshToken,
+    }),
     { expirationTtl: TOKEN_TTL_SECONDS }
   );
 
-  return json({
-    access_token: accessToken,
-    token_type: "Bearer",
-    expires_in: TOKEN_TTL_SECONDS,
-    scope: "mcp",
-  });
-}
-
-async function handleClientCredentialsGrant(
-  body: URLSearchParams,
-  env: Env,
-  _origin: string
-): Promise<Response> {
-  const clientId = body.get("client_id") ?? "";
-  const clientSecret = body.get("client_secret") ?? "";
-
-  if (!clientId || !clientSecret) {
-    return oauthError("invalid_client", "client_id and client_secret required");
+  // Pre-warm the Strava access token cache so the first MCP call is fast
+  const stravaTokenTtl =
+    codeRecord.stravaTokenExpiresAt - Math.floor(Date.now() / 1000) - 300;
+  if (stravaTokenTtl > 0) {
+    await env.TOKEN_CACHE.put(
+      stravaTokenCacheKey(accessToken),
+      JSON.stringify({
+        access_token: codeRecord.stravaAccessToken,
+        expires_at: codeRecord.stravaTokenExpiresAt,
+      }),
+      { expirationTtl: stravaTokenTtl }
+    );
   }
-
-  // Look up the registered client
-  const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
-  if (!clientRaw) {
-    return oauthError("invalid_client", "Unknown client");
-  }
-  const client = JSON.parse(clientRaw) as ClientRecord;
-
-  if (!client.client_secret || client.client_secret !== clientSecret) {
-    return oauthError("invalid_client", "Invalid client credentials");
-  }
-
-  const accessToken = generateToken();
-  await env.TOKEN_CACHE.put(
-    KV.token(accessToken),
-    JSON.stringify({ clientId, issuedAt: Date.now() }),
-    { expirationTtl: TOKEN_TTL_SECONDS }
-  );
 
   return json({
     access_token: accessToken,
@@ -402,77 +439,4 @@ function oauthError(error: string, description: string): Response {
     status: 400,
     headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
   });
-}
-
-// ---------------------------------------------------------------------------
-// Authorization HTML page
-// ---------------------------------------------------------------------------
-
-interface AuthPageParams {
-  clientName: string;
-  clientId: string;
-  redirectUri: string;
-  state: string;
-  codeChallenge: string;
-  codeChallengeMethod: string;
-  origin: string;
-}
-
-function authorizePage(p: AuthPageParams): string {
-  const esc = (s: string) => s.replace(/[&<>"']/g, (c) =>
-    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] ?? c)
-  );
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Authorise Strava MCP</title>
-  <style>
-    *{box-sizing:border-box;margin:0;padding:0}
-    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f5f5f5;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem}
-    .card{background:#fff;border-radius:12px;box-shadow:0 2px 16px rgba(0,0,0,.12);padding:2rem;max-width:420px;width:100%}
-    .logo{font-size:2rem;text-align:center;margin-bottom:1rem}
-    h1{font-size:1.25rem;font-weight:600;text-align:center;color:#111;margin-bottom:.5rem}
-    .sub{font-size:.9rem;color:#555;text-align:center;margin-bottom:1.5rem;line-height:1.5}
-    .client{background:#f8f8f8;border:1px solid #e0e0e0;border-radius:8px;padding:.75rem 1rem;font-size:.85rem;color:#333;margin-bottom:1.5rem;word-break:break-all}
-    .scopes{font-size:.85rem;color:#444;margin-bottom:1.5rem}
-    .scopes li{list-style:none;padding:.3rem 0;display:flex;align-items:center;gap:.5rem}
-    .scopes li::before{content:"✓";color:#22c55e;font-weight:700}
-    .btn-row{display:flex;gap:.75rem}
-    .btn{flex:1;padding:.7rem 1rem;border:none;border-radius:8px;font-size:.95rem;font-weight:500;cursor:pointer;transition:opacity .15s}
-    .btn-allow{background:#f97316;color:#fff}
-    .btn-deny{background:#f3f4f6;color:#374151}
-    .btn:hover{opacity:.9}
-    .warning{font-size:.8rem;color:#888;text-align:center;margin-top:1rem}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <div class="logo">🏃</div>
-    <h1>Authorise Strava MCP</h1>
-    <p class="sub"><strong>${esc(p.clientName)}</strong> is requesting access to your Strava running data.</p>
-    <div class="client">${esc(p.redirectUri.split("?")[0])}</div>
-    <ul class="scopes">
-      <li>Read your activities and stream data</li>
-      <li>Read your profile and zones</li>
-      <li>Read your segments and routes</li>
-    </ul>
-    <form method="POST" action="/oauth/authorize">
-      <input type="hidden" name="approved" value="true">
-      <input type="hidden" name="client_id" value="${esc(p.clientId)}">
-      <input type="hidden" name="redirect_uri" value="${esc(p.redirectUri)}">
-      <input type="hidden" name="state" value="${esc(p.state)}">
-      <input type="hidden" name="code_challenge" value="${esc(p.codeChallenge)}">
-      <input type="hidden" name="code_challenge_method" value="${esc(p.codeChallengeMethod)}">
-      <div class="btn-row">
-        <button type="submit" class="btn btn-allow">Authorise</button>
-        <button type="submit" class="btn btn-deny" formaction="/oauth/authorize"
-          onclick="this.form.querySelector('[name=approved]').value='false'">Deny</button>
-      </div>
-    </form>
-    <p class="warning">Only approve if you initiated this request.</p>
-  </div>
-</body>
-</html>`;
 }

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,0 +1,478 @@
+import type { Env } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// KV key namespacing
+// ---------------------------------------------------------------------------
+const KV = {
+  code: (c: string) => `oauth:code:${c}`,
+  token: (t: string) => `oauth:token:${t}`,
+  client: (id: string) => `oauth:client:${id}`,
+};
+
+const CODE_TTL_SECONDS = 600; // 10 minutes
+const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
+
+// ---------------------------------------------------------------------------
+// Routing
+// ---------------------------------------------------------------------------
+
+export function isOAuthPath(pathname: string): boolean {
+  return (
+    pathname === "/.well-known/oauth-authorization-server" ||
+    pathname === "/.well-known/oauth-protected-resource" ||
+    pathname.startsWith("/oauth/")
+  );
+}
+
+export async function handleOAuth(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const { pathname, origin } = url;
+
+  if (pathname === "/.well-known/oauth-authorization-server") {
+    return authServerMetadata(origin);
+  }
+  if (pathname === "/.well-known/oauth-protected-resource") {
+    return protectedResourceMetadata(origin);
+  }
+  if (pathname === "/oauth/register" && request.method === "POST") {
+    return dynamicRegistration(request, env, origin);
+  }
+  if (pathname === "/oauth/authorize") {
+    if (request.method === "GET") return authorizeGet(request, env, origin);
+    if (request.method === "POST") return authorizePost(request, env, origin);
+  }
+  if (pathname === "/oauth/token" && request.method === "POST") {
+    return tokenEndpoint(request, env, origin);
+  }
+  return new Response("Not Found", { status: 404 });
+}
+
+// ---------------------------------------------------------------------------
+// Validate an OAuth Bearer token (issued by this server)
+// ---------------------------------------------------------------------------
+
+export async function isValidOAuthToken(token: string, env: Env): Promise<boolean> {
+  const record = await env.TOKEN_CACHE.get(KV.token(token));
+  return record !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+function authServerMetadata(origin: string): Response {
+  return json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/oauth/authorize`,
+    token_endpoint: `${origin}/oauth/token`,
+    registration_endpoint: `${origin}/oauth/register`,
+    scopes_supported: ["mcp"],
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "client_credentials"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+  });
+}
+
+function protectedResourceMetadata(origin: string): Response {
+  return json({
+    resource: origin,
+    authorization_servers: [origin],
+    bearer_methods_supported: ["header"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic client registration (RFC 7591)
+// ---------------------------------------------------------------------------
+
+interface ClientRecord {
+  client_id: string;
+  client_secret: string | null;
+  redirect_uris: string[];
+  client_name?: string;
+}
+
+async function dynamicRegistration(
+  request: Request,
+  env: Env,
+  _origin: string
+): Promise<Response> {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return oauthError("invalid_request", "Invalid JSON body");
+  }
+
+  const redirectUris = body["redirect_uris"];
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+    return oauthError("invalid_request", "redirect_uris is required");
+  }
+
+  const clientId = generateToken();
+  // Public clients (PKCE) don't need a client_secret
+  const isPublic = body["token_endpoint_auth_method"] === "none";
+  const clientSecret = isPublic ? null : generateToken();
+
+  const record: ClientRecord = {
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uris: redirectUris as string[],
+    client_name: typeof body["client_name"] === "string" ? body["client_name"] : undefined,
+  };
+
+  await env.TOKEN_CACHE.put(KV.client(clientId), JSON.stringify(record));
+
+  return json(
+    {
+      client_id: clientId,
+      ...(clientSecret ? { client_secret: clientSecret } : {}),
+      redirect_uris: redirectUris,
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: isPublic ? "none" : "client_secret_post",
+    },
+    201
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Authorization endpoint
+// ---------------------------------------------------------------------------
+
+interface AuthParams {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  scope?: string;
+}
+
+async function authorizeGet(
+  request: Request,
+  env: Env,
+  origin: string
+): Promise<Response> {
+  const url = new URL(request.url);
+  const p = url.searchParams;
+
+  const clientId = p.get("client_id") ?? "";
+  const redirectUri = p.get("redirect_uri") ?? "";
+  const state = p.get("state") ?? "";
+  const codeChallenge = p.get("code_challenge") ?? "";
+  const codeChallengeMethod = p.get("code_challenge_method") ?? "S256";
+  const responseType = p.get("response_type");
+
+  if (responseType !== "code") {
+    return oauthError("unsupported_response_type", "Only 'code' is supported");
+  }
+  if (!clientId || !redirectUri || !codeChallenge) {
+    return oauthError("invalid_request", "Missing required parameters");
+  }
+
+  // Validate registered client
+  const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
+  if (!clientRaw) {
+    return oauthError("invalid_client", "Unknown client_id");
+  }
+  const client = JSON.parse(clientRaw) as ClientRecord;
+  if (!client.redirect_uris.includes(redirectUri)) {
+    return oauthError("invalid_request", "redirect_uri not registered for this client");
+  }
+
+  const clientName = client.client_name ?? clientId;
+
+  return new Response(authorizePage({ clientName, clientId, redirectUri, state, codeChallenge, codeChallengeMethod, origin }), {
+    headers: { "Content-Type": "text/html;charset=UTF-8" },
+  });
+}
+
+async function authorizePost(
+  request: Request,
+  env: Env,
+  origin: string
+): Promise<Response> {
+  let body: URLSearchParams;
+  try {
+    body = new URLSearchParams(await request.text());
+  } catch {
+    return oauthError("invalid_request", "Invalid form body");
+  }
+
+  const approved = body.get("approved") === "true";
+  const clientId = body.get("client_id") ?? "";
+  const redirectUri = body.get("redirect_uri") ?? "";
+  const state = body.get("state") ?? "";
+  const codeChallenge = body.get("code_challenge") ?? "";
+  const codeChallengeMethod = body.get("code_challenge_method") ?? "S256";
+
+  if (!approved) {
+    const denied = new URL(redirectUri);
+    denied.searchParams.set("error", "access_denied");
+    if (state) denied.searchParams.set("state", state);
+    return Response.redirect(denied.toString(), 302);
+  }
+
+  // Validate registered client again
+  const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
+  if (!clientRaw) {
+    return oauthError("invalid_client", "Unknown client_id");
+  }
+  const client = JSON.parse(clientRaw) as ClientRecord;
+  if (!client.redirect_uris.includes(redirectUri)) {
+    return oauthError("invalid_request", "redirect_uri mismatch");
+  }
+
+  const code = generateToken();
+  const codeRecord: AuthParams & { used: boolean } = {
+    clientId,
+    redirectUri,
+    state,
+    codeChallenge,
+    codeChallengeMethod,
+    used: false,
+  };
+  await env.TOKEN_CACHE.put(KV.code(code), JSON.stringify(codeRecord), {
+    expirationTtl: CODE_TTL_SECONDS,
+  });
+
+  const redirectUrl = new URL(redirectUri);
+  redirectUrl.searchParams.set("code", code);
+  if (state) redirectUrl.searchParams.set("state", state);
+  void origin;
+  return Response.redirect(redirectUrl.toString(), 302);
+}
+
+// ---------------------------------------------------------------------------
+// Token endpoint
+// ---------------------------------------------------------------------------
+
+async function tokenEndpoint(
+  request: Request,
+  env: Env,
+  origin: string
+): Promise<Response> {
+  let body: URLSearchParams;
+  try {
+    const text = await request.text();
+    body = new URLSearchParams(text);
+  } catch {
+    return oauthError("invalid_request", "Invalid request body");
+  }
+
+  const grantType = body.get("grant_type");
+
+  if (grantType === "authorization_code") {
+    return handleAuthCodeGrant(body, env, origin);
+  }
+  if (grantType === "client_credentials") {
+    return handleClientCredentialsGrant(body, env, origin);
+  }
+  return oauthError("unsupported_grant_type", `Unsupported grant_type: ${grantType}`);
+}
+
+async function handleAuthCodeGrant(
+  body: URLSearchParams,
+  env: Env,
+  _origin: string
+): Promise<Response> {
+  const code = body.get("code") ?? "";
+  const clientId = body.get("client_id") ?? "";
+  const redirectUri = body.get("redirect_uri") ?? "";
+  const codeVerifier = body.get("code_verifier") ?? "";
+
+  if (!code || !clientId || !redirectUri || !codeVerifier) {
+    return oauthError("invalid_request", "Missing required parameters");
+  }
+
+  const codeRaw = await env.TOKEN_CACHE.get(KV.code(code));
+  if (!codeRaw) {
+    return oauthError("invalid_grant", "Authorization code not found or expired");
+  }
+
+  const codeRecord = JSON.parse(codeRaw) as AuthParams & { used: boolean };
+
+  if (codeRecord.used) {
+    return oauthError("invalid_grant", "Authorization code already used");
+  }
+  if (codeRecord.clientId !== clientId) {
+    return oauthError("invalid_grant", "client_id mismatch");
+  }
+  if (codeRecord.redirectUri !== redirectUri) {
+    return oauthError("invalid_grant", "redirect_uri mismatch");
+  }
+  if (!(await verifyPKCE(codeVerifier, codeRecord.codeChallenge))) {
+    return oauthError("invalid_grant", "PKCE verification failed");
+  }
+
+  // Mark code as used and delete it
+  await env.TOKEN_CACHE.delete(KV.code(code));
+
+  const accessToken = generateToken();
+  await env.TOKEN_CACHE.put(
+    KV.token(accessToken),
+    JSON.stringify({ clientId, issuedAt: Date.now() }),
+    { expirationTtl: TOKEN_TTL_SECONDS }
+  );
+
+  return json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: TOKEN_TTL_SECONDS,
+    scope: "mcp",
+  });
+}
+
+async function handleClientCredentialsGrant(
+  body: URLSearchParams,
+  env: Env,
+  _origin: string
+): Promise<Response> {
+  const clientId = body.get("client_id") ?? "";
+  const clientSecret = body.get("client_secret") ?? "";
+
+  if (!clientId || !clientSecret) {
+    return oauthError("invalid_client", "client_id and client_secret required");
+  }
+
+  // Look up the registered client
+  const clientRaw = await env.TOKEN_CACHE.get(KV.client(clientId));
+  if (!clientRaw) {
+    return oauthError("invalid_client", "Unknown client");
+  }
+  const client = JSON.parse(clientRaw) as ClientRecord;
+
+  if (!client.client_secret || client.client_secret !== clientSecret) {
+    return oauthError("invalid_client", "Invalid client credentials");
+  }
+
+  const accessToken = generateToken();
+  await env.TOKEN_CACHE.put(
+    KV.token(accessToken),
+    JSON.stringify({ clientId, issuedAt: Date.now() }),
+    { expirationTtl: TOKEN_TTL_SECONDS }
+  );
+
+  return json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: TOKEN_TTL_SECONDS,
+    scope: "mcp",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PKCE
+// ---------------------------------------------------------------------------
+
+async function verifyPKCE(verifier: string, challenge: string): Promise<boolean> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const base64url = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return base64url === challenge;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+function oauthError(error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status: 400,
+    headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Authorization HTML page
+// ---------------------------------------------------------------------------
+
+interface AuthPageParams {
+  clientName: string;
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  codeChallengeMethod: string;
+  origin: string;
+}
+
+function authorizePage(p: AuthPageParams): string {
+  const esc = (s: string) => s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] ?? c)
+  );
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Authorise Strava MCP</title>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f5f5f5;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem}
+    .card{background:#fff;border-radius:12px;box-shadow:0 2px 16px rgba(0,0,0,.12);padding:2rem;max-width:420px;width:100%}
+    .logo{font-size:2rem;text-align:center;margin-bottom:1rem}
+    h1{font-size:1.25rem;font-weight:600;text-align:center;color:#111;margin-bottom:.5rem}
+    .sub{font-size:.9rem;color:#555;text-align:center;margin-bottom:1.5rem;line-height:1.5}
+    .client{background:#f8f8f8;border:1px solid #e0e0e0;border-radius:8px;padding:.75rem 1rem;font-size:.85rem;color:#333;margin-bottom:1.5rem;word-break:break-all}
+    .scopes{font-size:.85rem;color:#444;margin-bottom:1.5rem}
+    .scopes li{list-style:none;padding:.3rem 0;display:flex;align-items:center;gap:.5rem}
+    .scopes li::before{content:"✓";color:#22c55e;font-weight:700}
+    .btn-row{display:flex;gap:.75rem}
+    .btn{flex:1;padding:.7rem 1rem;border:none;border-radius:8px;font-size:.95rem;font-weight:500;cursor:pointer;transition:opacity .15s}
+    .btn-allow{background:#f97316;color:#fff}
+    .btn-deny{background:#f3f4f6;color:#374151}
+    .btn:hover{opacity:.9}
+    .warning{font-size:.8rem;color:#888;text-align:center;margin-top:1rem}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="logo">🏃</div>
+    <h1>Authorise Strava MCP</h1>
+    <p class="sub"><strong>${esc(p.clientName)}</strong> is requesting access to your Strava running data.</p>
+    <div class="client">${esc(p.redirectUri.split("?")[0])}</div>
+    <ul class="scopes">
+      <li>Read your activities and stream data</li>
+      <li>Read your profile and zones</li>
+      <li>Read your segments and routes</li>
+    </ul>
+    <form method="POST" action="/oauth/authorize">
+      <input type="hidden" name="approved" value="true">
+      <input type="hidden" name="client_id" value="${esc(p.clientId)}">
+      <input type="hidden" name="redirect_uri" value="${esc(p.redirectUri)}">
+      <input type="hidden" name="state" value="${esc(p.state)}">
+      <input type="hidden" name="code_challenge" value="${esc(p.codeChallenge)}">
+      <input type="hidden" name="code_challenge_method" value="${esc(p.codeChallengeMethod)}">
+      <div class="btn-row">
+        <button type="submit" class="btn btn-allow">Authorise</button>
+        <button type="submit" class="btn btn-deny" formaction="/oauth/authorize"
+          onclick="this.form.querySelector('[name=approved]').value='false'">Deny</button>
+      </div>
+    </form>
+    <p class="warning">Only approve if you initiated this request.</p>
+  </div>
+</body>
+</html>`;
+}

--- a/src/strava/client.ts
+++ b/src/strava/client.ts
@@ -1,10 +1,12 @@
 import type { Env } from "../types.js";
+import { stravaTokenCacheKey } from "../oauth.js";
 import type { StravaRateLimitInfo } from "./types.js";
 
 const BASE_URL = "https://www.strava.com/api/v3";
 const TOKEN_URL = "https://www.strava.com/oauth/token";
-const TOKEN_KV_KEY = "strava:access_token";
+const STATIC_TOKEN_KV_KEY = "strava:access_token";
 const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
+const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 interface CachedToken {
   access_token: string;
@@ -15,6 +17,12 @@ interface TokenResponse {
   access_token: string;
   refresh_token: string;
   expires_at: number;
+}
+
+interface OAuthTokenRecord {
+  clientId: string;
+  issuedAt: number;
+  stravaRefreshToken?: string;
 }
 
 export class StravaApiError extends Error {
@@ -32,10 +40,26 @@ export class StravaApiError extends Error {
 export class StravaClient {
   public lastRateLimitInfo: StravaRateLimitInfo | null = null;
 
-  constructor(private readonly env: Env) {}
+  constructor(
+    private readonly env: Env,
+    // When set, tokens are looked up per-user from TOKEN_CACHE rather than
+    // using the static STRAVA_REFRESH_TOKEN secret.
+    private readonly userOAuthToken?: string
+  ) {}
 
   async getAccessToken(): Promise<string> {
-    const cached = await this.env.TOKEN_CACHE.get(TOKEN_KV_KEY);
+    if (this.userOAuthToken) {
+      return this.getUserAccessToken(this.userOAuthToken);
+    }
+    return this.getStaticAccessToken();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static (single-user) token path — uses env.STRAVA_REFRESH_TOKEN
+  // ---------------------------------------------------------------------------
+
+  private async getStaticAccessToken(): Promise<string> {
+    const cached = await this.env.TOKEN_CACHE.get(STATIC_TOKEN_KV_KEY);
     if (cached) {
       const { access_token, expires_at } = JSON.parse(cached) as CachedToken;
       if (Math.floor(Date.now() / 1000) < expires_at - TOKEN_EXPIRY_BUFFER_SECONDS) {
@@ -43,13 +67,77 @@ export class StravaClient {
       }
     }
 
+    const data = await this.refreshStravaToken(this.env.STRAVA_REFRESH_TOKEN);
+
+    const ttlSeconds =
+      data.expires_at - Math.floor(Date.now() / 1000) - TOKEN_EXPIRY_BUFFER_SECONDS;
+    if (ttlSeconds > 0) {
+      await this.env.TOKEN_CACHE.put(
+        STATIC_TOKEN_KV_KEY,
+        JSON.stringify({ access_token: data.access_token, expires_at: data.expires_at }),
+        { expirationTtl: ttlSeconds }
+      );
+    }
+
+    return data.access_token;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-user token path — tokens stored in TOKEN_CACHE keyed by OAuth token
+  // ---------------------------------------------------------------------------
+
+  private async getUserAccessToken(oauthToken: string): Promise<string> {
+    const cacheKey = stravaTokenCacheKey(oauthToken);
+
+    const cached = await this.env.TOKEN_CACHE.get(cacheKey);
+    if (cached) {
+      const { access_token, expires_at } = JSON.parse(cached) as CachedToken;
+      if (Math.floor(Date.now() / 1000) < expires_at - TOKEN_EXPIRY_BUFFER_SECONDS) {
+        return access_token;
+      }
+    }
+
+    const recordRaw = await this.env.TOKEN_CACHE.get(`oauth:token:${oauthToken}`);
+    if (!recordRaw) {
+      throw new StravaApiError(401, "OAuth token not found — please re-authorize");
+    }
+    const record = JSON.parse(recordRaw) as OAuthTokenRecord;
+    if (!record.stravaRefreshToken) {
+      throw new StravaApiError(401, "No Strava account linked to this token — please re-authorize");
+    }
+
+    const data = await this.refreshStravaToken(record.stravaRefreshToken);
+
+    const ttlSeconds =
+      data.expires_at - Math.floor(Date.now() / 1000) - TOKEN_EXPIRY_BUFFER_SECONDS;
+    if (ttlSeconds > 0) {
+      await this.env.TOKEN_CACHE.put(
+        cacheKey,
+        JSON.stringify({ access_token: data.access_token, expires_at: data.expires_at }),
+        { expirationTtl: ttlSeconds }
+      );
+    }
+
+    // Update the token record if Strava rotated the refresh token
+    if (data.refresh_token !== record.stravaRefreshToken) {
+      await this.env.TOKEN_CACHE.put(
+        `oauth:token:${oauthToken}`,
+        JSON.stringify({ ...record, stravaRefreshToken: data.refresh_token }),
+        { expirationTtl: TOKEN_TTL_SECONDS }
+      );
+    }
+
+    return data.access_token;
+  }
+
+  private async refreshStravaToken(refreshToken: string): Promise<TokenResponse> {
     const response = await fetch(TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         client_id: this.env.STRAVA_CLIENT_ID,
         client_secret: this.env.STRAVA_CLIENT_SECRET,
-        refresh_token: this.env.STRAVA_REFRESH_TOKEN,
+        refresh_token: refreshToken,
         grant_type: "refresh_token",
       }),
     });
@@ -61,20 +149,12 @@ export class StravaClient {
       );
     }
 
-    const data = (await response.json()) as TokenResponse;
-    const ttlSeconds =
-      data.expires_at - Math.floor(Date.now() / 1000) - TOKEN_EXPIRY_BUFFER_SECONDS;
-
-    if (ttlSeconds > 0) {
-      await this.env.TOKEN_CACHE.put(
-        TOKEN_KV_KEY,
-        JSON.stringify({ access_token: data.access_token, expires_at: data.expires_at }),
-        { expirationTtl: ttlSeconds }
-      );
-    }
-
-    return data.access_token;
+    return (await response.json()) as TokenResponse;
   }
+
+  // ---------------------------------------------------------------------------
+  // HTTP
+  // ---------------------------------------------------------------------------
 
   async fetch(path: string, options?: RequestInit): Promise<Response> {
     const token = await this.getAccessToken();
@@ -98,7 +178,11 @@ export class StravaClient {
     this.lastRateLimitInfo = parseRateLimitHeaders(response.headers);
 
     if (response.status === 401 && !isRetry) {
-      await this.env.TOKEN_CACHE.delete(TOKEN_KV_KEY);
+      // Clear the cached access token so the next attempt does a fresh refresh
+      const cacheKey = this.userOAuthToken
+        ? stravaTokenCacheKey(this.userOAuthToken)
+        : STATIC_TOKEN_KV_KEY;
+      await this.env.TOKEN_CACHE.delete(cacheKey);
       const freshToken = await this.getAccessToken();
       return this.doFetch(path, freshToken, options, true);
     }

--- a/src/strava/errors.ts
+++ b/src/strava/errors.ts
@@ -1,5 +1,12 @@
 import { StravaApiError } from "./client.js";
 
+// Throws StravaApiError so handleStravaError can map the status to a known code.
+export function assertOk(res: Response): void {
+  if (!res.ok) {
+    throw new StravaApiError(res.status, res.statusText || `HTTP ${res.status}`);
+  }
+}
+
 export type McpErrorCode =
   | "STRAVA_RATE_LIMIT"
   | "STRAVA_AUTH"

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -1,12 +1,50 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { StravaClient } from "./client.js";
-import { handleStravaError } from "./errors.js";
+import { handleStravaError, assertOk } from "./errors.js";
 import { fetchActivityStreams } from "./streams.js";
 import type { StreamType } from "./types.js";
 
 function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+
+const MAX_FILTER_PAGES = 10;
+const FILTER_PAGE_SIZE = 200;
+
+// Exported for unit testing. Paginates /athlete/activities in fixed-size pages
+// and accumulates activities matching activityType until limit is reached or
+// MAX_FILTER_PAGES is exhausted — whichever comes first.
+export async function fetchFilteredActivities(
+  client: Pick<StravaClient, "fetch">,
+  limit: number,
+  activityType: string,
+  before?: number,
+  after?: number
+): Promise<unknown[]> {
+  const matches: unknown[] = [];
+  let page = 1;
+  while (matches.length < limit && page <= MAX_FILTER_PAGES) {
+    const params = new URLSearchParams({
+      page: String(page),
+      per_page: String(FILTER_PAGE_SIZE),
+    });
+    if (before) params.set("before", String(before));
+    if (after) params.set("after", String(after));
+    const res = await client.fetch(`/athlete/activities?${params}`);
+    assertOk(res);
+    const pageData = (await res.json()) as unknown[];
+    for (const a of pageData) {
+      const act = a as Record<string, unknown>;
+      if (act["type"] === activityType || act["sport_type"] === activityType) {
+        matches.push(a);
+        if (matches.length >= limit) break;
+      }
+    }
+    if (pageData.length < FILTER_PAGE_SIZE) break; // no more activities on Strava
+    page++;
+  }
+  return matches;
 }
 
 export function registerStravaTools(
@@ -22,7 +60,7 @@ export function registerStravaTools(
     async () => {
       try {
         const res = await client.fetch("/athlete");
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -42,6 +80,12 @@ export function registerStravaTools(
     },
     async ({ limit, before, after, activity_type }) => {
       try {
+        if (activity_type) {
+          return ok(
+            await fetchFilteredActivities(client, limit, activity_type, before, after)
+          );
+        }
+        // Unfiltered path — unchanged: page with per_page=limit to minimise API calls
         const activities: unknown[] = [];
         let page = 1;
         while (activities.length < limit) {
@@ -50,21 +94,14 @@ export function registerStravaTools(
           if (before) params.set("before", String(before));
           if (after) params.set("after", String(after));
           const res = await client.fetch(`/athlete/activities?${params}`);
-          if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+          assertOk(res);
           const page_data = (await res.json()) as unknown[];
           if (page_data.length === 0) break;
           activities.push(...page_data);
           if (page_data.length < perPage) break;
           page++;
         }
-        const filtered = activity_type
-          ? activities.filter(
-              (a) =>
-                (a as Record<string, unknown>)["type"] === activity_type ||
-                (a as Record<string, unknown>)["sport_type"] === activity_type
-            )
-          : activities;
-        return ok(filtered.slice(0, limit));
+        return ok(activities.slice(0, limit));
       } catch (err) {
         return handleStravaError(err);
       }
@@ -81,7 +118,7 @@ export function registerStravaTools(
     async ({ activity_id }) => {
       try {
         const res = await client.fetch(`/activities/${activity_id}`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -145,7 +182,7 @@ export function registerStravaTools(
     async ({ activity_id }) => {
       try {
         const res = await client.fetch(`/activities/${activity_id}/zones`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -161,7 +198,7 @@ export function registerStravaTools(
     async () => {
       try {
         const res = await client.fetch("/athlete/zones");
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -178,10 +215,10 @@ export function registerStravaTools(
       try {
         // Need athlete ID first
         const athleteRes = await client.fetch("/athlete");
-        if (!athleteRes.ok) throw Object.assign(new Error(athleteRes.statusText), { status: athleteRes.status });
+        assertOk(athleteRes);
         const athlete = (await athleteRes.json()) as { id: number };
         const statsRes = await client.fetch(`/athletes/${athlete.id}/stats`);
-        if (!statsRes.ok) throw Object.assign(new Error(statsRes.statusText), { status: statsRes.status });
+        assertOk(statsRes);
         return ok(await statsRes.json());
       } catch (err) {
         return handleStravaError(err);
@@ -199,7 +236,7 @@ export function registerStravaTools(
     async ({ segment_id }) => {
       try {
         const res = await client.fetch(`/segments/${segment_id}`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -223,7 +260,7 @@ export function registerStravaTools(
         if (start_date_local) params.set("start_date_local", start_date_local);
         if (end_date_local) params.set("end_date_local", end_date_local);
         const res = await client.fetch(`/segments/${segment_id}/all_efforts?${params}`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -253,7 +290,7 @@ export function registerStravaTools(
         const res = await client.fetch(
           `/segment_efforts/${effort_id}/streams?keys=${keys}&resolution=all&series_type=time`
         );
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         const streamsArray = (await res.json()) as { type: string; data: unknown[] }[];
         const present = streamsArray.map((s) => s.type);
         const requested = stream_types ?? ["time", "distance", "altitude", "latlng"];
@@ -291,7 +328,7 @@ export function registerStravaTools(
         const params = new URLSearchParams({ bounds });
         if (activity_type) params.set("activity_type", activity_type);
         const res = await client.fetch(`/segments/explore?${params}`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -310,11 +347,11 @@ export function registerStravaTools(
     async ({ page, per_page }) => {
       try {
         const athleteRes = await client.fetch("/athlete");
-        if (!athleteRes.ok) throw Object.assign(new Error(athleteRes.statusText), { status: athleteRes.status });
+        assertOk(athleteRes);
         const athlete = (await athleteRes.json()) as { id: number };
         const params = new URLSearchParams({ page: String(page), per_page: String(per_page) });
         const res = await client.fetch(`/athletes/${athlete.id}/routes?${params}`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);
@@ -335,7 +372,7 @@ export function registerStravaTools(
           client.fetch(`/routes/${route_id}`),
           client.fetch(`/routes/${route_id}/streams`),
         ]);
-        if (!routeRes.ok) throw Object.assign(new Error(routeRes.statusText), { status: routeRes.status });
+        assertOk(routeRes);
         const route = await routeRes.json();
         let streams: unknown = null;
         if (streamsRes.ok) {
@@ -356,7 +393,7 @@ export function registerStravaTools(
     async () => {
       try {
         const res = await client.fetch("/athlete");
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         const athlete = (await res.json()) as { bikes?: unknown[]; shoes?: unknown[] };
         return ok({ bikes: athlete.bikes ?? [], shoes: athlete.shoes ?? [] });
       } catch (err) {
@@ -375,7 +412,7 @@ export function registerStravaTools(
     async ({ activity_id }) => {
       try {
         const res = await client.fetch(`/activities/${activity_id}/laps`);
-        if (!res.ok) throw Object.assign(new Error(res.statusText), { status: res.status });
+        assertOk(res);
         return ok(await res.json());
       } catch (err) {
         return handleStravaError(err);

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { registerStravaTools } from "../src/strava/tools.js";
+import { fetchFilteredActivities } from "../src/strava/tools.js";
+import type { StravaClient } from "../src/strava/client.js";
+
+// ---------------------------------------------------------------------------
+// Shared test infrastructure
+// ---------------------------------------------------------------------------
+
+type FetchRoute = [string, unknown, number?]; // [path-substring, body, status=200]
+
+function mockStravaClient(routes: FetchRoute[]): Pick<StravaClient, "fetch"> & { fetch: ReturnType<typeof vi.fn> } {
+  return {
+    fetch: vi.fn().mockImplementation(async (path: string) => {
+      // Strip query string for matching so exact patterns work with parameterised URLs
+      const pathBase = path.split("?")[0];
+      const route = routes.find(([pattern]) => pathBase === pattern);
+      if (!route) return new Response("Not Found", { status: 404, statusText: "Not Found" });
+      const [, body, status = 200] = route;
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  };
+}
+
+function mockKv(): KVNamespace {
+  const store = new Map<string, string>();
+  return {
+    get: vi.fn().mockImplementation(async (key: string) => store.get(key) ?? null),
+    put: vi.fn().mockImplementation(async (key: string, value: string) => { store.set(key, value); }),
+    delete: vi.fn().mockImplementation(async (key: string) => { store.delete(key); }),
+    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cacheStatus: null }),
+    getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null, cacheStatus: null }),
+  } as unknown as KVNamespace;
+}
+
+interface Harness {
+  mcpClient: Client;
+  mockFetch: ReturnType<typeof vi.fn>;
+  close(): Promise<void>;
+}
+
+async function createHarness(routes: FetchRoute[]): Promise<Harness> {
+  const stravaClient = mockStravaClient(routes);
+  const server = new McpServer({ name: "test", version: "0.0.0" });
+  registerStravaTools(server, stravaClient as unknown as StravaClient, mockKv());
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const mcpClient = new Client({ name: "test-client", version: "0.0.0" });
+  await server.connect(serverTransport);
+  await mcpClient.connect(clientTransport);
+
+  return {
+    mcpClient,
+    mockFetch: stravaClient.fetch,
+    close: () => mcpClient.close(),
+  };
+}
+
+function parseResult(result: Awaited<ReturnType<Client["callTool"]>>): unknown {
+  const content = result.content as { type: string; text?: string }[];
+  const text = content.find((c) => c.type === "text");
+  return text?.text ? JSON.parse(text.text) : null;
+}
+
+// ---------------------------------------------------------------------------
+// fetchFilteredActivities unit tests (called directly, no harness needed)
+// ---------------------------------------------------------------------------
+
+const run = (id: number) => ({ id, type: "Run", sport_type: "Run" });
+const ride = (id: number) => ({ id, type: "Ride", sport_type: "Ride" });
+
+function mockPaginatedClient(pages: unknown[][]): Pick<StravaClient, "fetch"> {
+  let page = 0;
+  return {
+    fetch: vi.fn().mockImplementation(async () => {
+      const data = pages[page++] ?? [];
+      return new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  };
+}
+
+describe("fetchFilteredActivities", () => {
+  it("paginates past a first page with no type matches", async () => {
+    const fullRunPage = Array.from({ length: 200 }, (_, i) => run(i));
+    const client = mockPaginatedClient([fullRunPage, [ride(201), ride(202)]]);
+    const result = await fetchFilteredActivities(client, 1, "Ride");
+    expect(result).toHaveLength(1);
+    expect((result[0] as { id: number }).id).toBe(201);
+    expect((client.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
+  it("threads before/after params through every page fetch", async () => {
+    const client = mockPaginatedClient([[run(1)], [ride(2)]]);
+    await fetchFilteredActivities(client, 1, "Ride", 1700000000, 1600000000);
+    const calls = (client.fetch as ReturnType<typeof vi.fn>).mock.calls as [string][];
+    for (const [path] of calls) {
+      expect(path).toContain("before=1700000000");
+      expect(path).toContain("after=1600000000");
+    }
+  });
+
+  it("stops at the page cap and returns what was found — does not error", async () => {
+    const fullRunPage = Array.from({ length: 200 }, (_, i) => run(i));
+    const pages = Array.from({ length: 11 }, () => fullRunPage);
+    const client = mockPaginatedClient(pages);
+    const result = await fetchFilteredActivities(client, 5, "Ride");
+    expect(result).toHaveLength(0);
+    expect((client.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeLessThanOrEqual(10);
+  });
+
+  it("stops early when limit is satisfied mid-page", async () => {
+    const client = mockPaginatedClient([[ride(1), ride(2), ride(3)]]);
+    const result = await fetchFilteredActivities(client, 2, "Ride");
+    expect(result).toHaveLength(2);
+    expect((client.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool integration tests (full MCP Client ↔ Server path via InMemoryTransport)
+// ---------------------------------------------------------------------------
+
+describe("get_athlete_profile", () => {
+  it("returns the athlete object from /athlete", async () => {
+    const h = await createHarness([["/athlete", { id: 1, firstname: "Ada", lastname: "L" }]]);
+    afterEach(() => h.close());
+    const data = parseResult(await h.mcpClient.callTool({ name: "get_athlete_profile", arguments: {} })) as { id: number };
+    expect(data.id).toBe(1);
+    expect(h.mockFetch).toHaveBeenCalledWith("/athlete");
+  });
+});
+
+describe("get_recent_activities", () => {
+  it("unfiltered: fetches with per_page=limit and returns the result", async () => {
+    const activities = [{ id: 1 }, { id: 2 }];
+    const h = await createHarness([["/athlete/activities", activities]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_recent_activities", arguments: { limit: 2 } })
+    ) as unknown[];
+    expect(data).toHaveLength(2);
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("per_page=2");
+  });
+
+  it("type-filtered: paginates until enough matches are found", async () => {
+    // First full page of runs, second page with a ride
+    const runPage = Array.from({ length: 200 }, () => ({ type: "Run", sport_type: "Run" }));
+    let callCount = 0;
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    h.mockFetch.mockImplementation(async () => {
+      const data = callCount++ === 0 ? runPage : [{ id: 77, type: "Ride", sport_type: "Ride" }];
+      return new Response(JSON.stringify(data), { status: 200 });
+    });
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_recent_activities", arguments: { limit: 1, activity_type: "Ride" } })
+    ) as { id: number }[];
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(77);
+    expect(h.mockFetch.mock.calls.length).toBe(2);
+  });
+});
+
+describe("get_activity_details", () => {
+  it("fetches /activities/:id and returns the response", async () => {
+    const h = await createHarness([["/activities/123", { id: 123, name: "Morning Run" }]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_details", arguments: { activity_id: 123 } })
+    ) as { id: number; name: string };
+    expect(data.id).toBe(123);
+    expect(data.name).toBe("Morning Run");
+  });
+
+  it("returns STRAVA_NOT_FOUND when the Strava fetch returns 404", async () => {
+    const h = await createHarness([["/activities/999", { message: "Record Not Found" }, 404]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_details", arguments: { activity_id: 999 } })
+    ) as { error: { code: string } };
+    expect(data.error.code).toBe("STRAVA_NOT_FOUND");
+  });
+});
+
+describe("get_activity_zones", () => {
+  it("fetches /activities/:id/zones", async () => {
+    const zones = [{ type: "heartrate", sensor_based: true, points: 10 }];
+    const h = await createHarness([["/activities/5/zones", zones]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_zones", arguments: { activity_id: 5 } })
+    ) as unknown[];
+    expect(data).toHaveLength(1);
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("/activities/5/zones");
+  });
+});
+
+describe("get_athlete_zones", () => {
+  it("fetches /athlete/zones", async () => {
+    const h = await createHarness([["/athlete/zones", { heart_rate: { zones: [] } }]]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({ name: "get_athlete_zones", arguments: {} });
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toBe("/athlete/zones");
+  });
+});
+
+describe("get_athlete_stats", () => {
+  it("uses the athlete id from /athlete for the stats URL", async () => {
+    const h = await createHarness([
+      ["/athlete", { id: 42 }],
+      ["/athletes/42/stats", { recent_run_totals: { count: 5 } }],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_athlete_stats", arguments: {} })
+    ) as { recent_run_totals: { count: number } };
+    expect(data.recent_run_totals.count).toBe(5);
+    const paths = (h.mockFetch.mock.calls as [string][]).map(([p]) => p);
+    expect(paths[0]).toBe("/athlete");
+    expect(paths[1]).toContain("/athletes/42/stats");
+  });
+
+  it("returns STRAVA_AUTH when the athlete fetch returns 401", async () => {
+    const h = await createHarness([["/athlete", null, 401]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_athlete_stats", arguments: {} })
+    ) as { error: { code: string } };
+    expect(data.error.code).toBe("STRAVA_AUTH");
+  });
+});
+
+describe("get_segment_details", () => {
+  it("fetches /segments/:id", async () => {
+    const h = await createHarness([["/segments/88", { id: 88, name: "Hard Climb" }]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_segment_details", arguments: { segment_id: 88 } })
+    ) as { id: number };
+    expect(data.id).toBe(88);
+  });
+});
+
+describe("list_my_segment_efforts", () => {
+  it("passes date filters through to the Strava URL", async () => {
+    const h = await createHarness([["/segments/77/all_efforts", [{ id: 1 }]]]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({
+      name: "list_my_segment_efforts",
+      arguments: { segment_id: 77, start_date_local: "2025-01-01T00:00:00Z", end_date_local: "2025-06-01T00:00:00Z" },
+    });
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("start_date_local=2025-01-01T00%3A00%3A00Z");
+    expect(path).toContain("end_date_local=2025-06-01T00%3A00%3A00Z");
+  });
+
+  it("works without date filters", async () => {
+    const h = await createHarness([["/segments/77/all_efforts", [{ id: 1 }, { id: 2 }]]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "list_my_segment_efforts", arguments: { segment_id: 77 } })
+    ) as unknown[];
+    expect(data).toHaveLength(2);
+  });
+});
+
+describe("get_segment_effort_streams", () => {
+  const streamData = [
+    { type: "time", data: [0, 1, 2] },
+    { type: "distance", data: [0.0, 5.1, 10.2] },
+  ];
+
+  it("reports which requested stream types are present vs missing", async () => {
+    const h = await createHarness([["/segment_efforts/55/streams", streamData]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_segment_effort_streams",
+        arguments: { effort_id: 55, stream_types: ["time", "distance", "altitude"] },
+      })
+    ) as { metadata: { stream_types_present: string[]; stream_types_missing: string[] }; data: Record<string, unknown> };
+    expect(data.metadata.stream_types_present).toEqual(["time", "distance"]);
+    expect(data.metadata.stream_types_missing).toEqual(["altitude"]);
+  });
+
+  it("uses default stream types when none specified", async () => {
+    const h = await createHarness([["/segment_efforts/55/streams", streamData]]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({ name: "get_segment_effort_streams", arguments: { effort_id: 55 } });
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("time");
+    expect(path).toContain("distance");
+    expect(path).toContain("altitude");
+    expect(path).toContain("latlng");
+  });
+
+  it("places stream arrays in the data field keyed by type", async () => {
+    const h = await createHarness([["/segment_efforts/55/streams", streamData]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_segment_effort_streams", arguments: { effort_id: 55 } })
+    ) as { data: { time?: number[]; distance?: number[] } };
+    expect(data.data.time).toEqual([0, 1, 2]);
+    expect(data.data.distance).toEqual([0.0, 5.1, 10.2]);
+  });
+});
+
+describe("explore_segments", () => {
+  it("passes the bounds param to Strava", async () => {
+    const h = await createHarness([["/segments/explore", { segments: [] }]]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({
+      name: "explore_segments",
+      arguments: { bounds: "37.821,-122.505,37.842,-122.465" },
+    });
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("bounds=37.821");
+  });
+
+  it("includes activity_type when specified", async () => {
+    const h = await createHarness([["/segments/explore", { segments: [] }]]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({
+      name: "explore_segments",
+      arguments: { bounds: "0,0,1,1", activity_type: "running" },
+    });
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("activity_type=running");
+  });
+});
+
+describe("list_routes", () => {
+  it("uses the athlete id from /athlete in the routes URL", async () => {
+    const h = await createHarness([
+      ["/athlete", { id: 99 }],
+      ["/athletes/99/routes", [{ id: 1 }]],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "list_routes", arguments: { page: 1, per_page: 10 } })
+    ) as unknown[];
+    expect(data).toHaveLength(1);
+    const paths = (h.mockFetch.mock.calls as [string][]).map(([p]) => p);
+    expect(paths[1]).toContain("/athletes/99/routes");
+  });
+
+  it("passes page and per_page params through", async () => {
+    const h = await createHarness([
+      ["/athlete", { id: 99 }],
+      ["/athletes/99/routes", []],
+    ]);
+    afterEach(() => h.close());
+    await h.mcpClient.callTool({ name: "list_routes", arguments: { page: 3, per_page: 50 } });
+    const [path] = h.mockFetch.mock.calls[1] as [string];
+    expect(path).toContain("page=3");
+    expect(path).toContain("per_page=50");
+  });
+});
+
+describe("get_route_details", () => {
+  it("returns both route data and stream data on success", async () => {
+    const h = await createHarness([
+      ["/routes/10", { id: 10, name: "Sunday Loop" }],
+      ["/routes/10/streams", [{ type: "latlng", data: [] }]],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_route_details", arguments: { route_id: 10 } })
+    ) as { route: { id: number }; streams: unknown };
+    expect(data.route.id).toBe(10);
+    expect(data.streams).not.toBeNull();
+  });
+
+  it("returns route with null streams when the streams fetch returns non-ok", async () => {
+    const h = await createHarness([
+      ["/routes/10", { id: 10 }],
+      ["/routes/10/streams", null, 403],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_route_details", arguments: { route_id: 10 } })
+    ) as { route: { id: number }; streams: unknown };
+    expect(data.route.id).toBe(10);
+    expect(data.streams).toBeNull();
+  });
+
+  it("returns STRAVA_NOT_FOUND when the route fetch returns 404", async () => {
+    const h = await createHarness([
+      ["/routes/10", null, 404],
+      ["/routes/10/streams", null, 404],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_route_details", arguments: { route_id: 10 } })
+    ) as { error: { code: string } };
+    expect(data.error.code).toBe("STRAVA_NOT_FOUND");
+  });
+});
+
+describe("list_gear", () => {
+  it("extracts bikes and shoes from the athlete response", async () => {
+    const h = await createHarness([[
+      "/athlete",
+      { bikes: [{ id: "b1", name: "Trek" }], shoes: [{ id: "g1", name: "Nike" }] },
+    ]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "list_gear", arguments: {} })
+    ) as { bikes: unknown[]; shoes: unknown[] };
+    expect(data.bikes).toHaveLength(1);
+    expect(data.shoes).toHaveLength(1);
+  });
+
+  it("returns empty arrays when the athlete has no gear fields", async () => {
+    const h = await createHarness([["/athlete", { id: 1 }]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "list_gear", arguments: {} })
+    ) as { bikes: unknown[]; shoes: unknown[] };
+    expect(data.bikes).toEqual([]);
+    expect(data.shoes).toEqual([]);
+  });
+});
+
+describe("get_activity_laps", () => {
+  it("fetches /activities/:id/laps", async () => {
+    const laps = [{ id: 1, lap_index: 1 }, { id: 2, lap_index: 2 }];
+    const h = await createHarness([["/activities/321/laps", laps]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_laps", arguments: { activity_id: 321 } })
+    ) as unknown[];
+    expect(data).toHaveLength(2);
+    const [path] = h.mockFetch.mock.calls[0] as [string];
+    expect(path).toContain("/activities/321/laps");
+  });
+});


### PR DESCRIPTION
## Summary

- **OAuth 2.0 authorization server** (`src/oauth.ts`) — implements RFC 6749 Authorization Code + PKCE, RFC 7591 Dynamic Client Registration, and discovery metadata. Enables claude.ai web connector integration without custom headers.
- **Multi-user Strava support** — `GET /oauth/authorize` now redirects to Strava's OAuth consent screen. A new `GET /oauth/strava-callback` route exchanges the Strava code and stores the user's refresh token in KV keyed by our OAuth access token. Each user's Strava tokens are managed independently; the static `MCP_AUTH_TOKEN` admin path still works unchanged.
- **`StravaClient` per-user token mode** — constructor accepts an optional `userOAuthToken`; reads and refreshes Strava tokens from KV per-user rather than the shared `STRAVA_REFRESH_TOKEN` secret.
- **Bug fix: `get_recent_activities` with `activity_type`** — was using `limit` as `per_page`, so a page of the wrong activity type would exhaust the budget before finding any matches. Now paginates in 200-item pages, accumulating type-filtered results up to `limit`, capped at 10 pages.
- **Bug fix: tool error codes** — all tool handlers were throwing plain `Error` for non-ok Strava responses, making `handleStravaError` always return `INTERNAL`. Added `assertOk()` to `errors.ts` — 404 now returns `STRAVA_NOT_FOUND`, 401 returns `STRAVA_AUTH`, etc.
- **Comprehensive tool test suite** — 29 new tests via `InMemoryTransport` (MCP Client ↔ Server end-to-end). Covers all 15 tools: two-step fetches, parallel fetch + graceful stream degradation, param threading, filtered pagination cap, and error code mapping.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` — 61 tests, all green (was 32 before this branch)
- [x] Deployed to `https://strava-mcp.git-c82.workers.dev`
- [x] Update Strava app Authorization Callback Domain to `strava-mcp.git-c82.workers.dev` before using OAuth flow

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)