### PR TITLE
Streams fix, sport-aware tools, summary aggregation, structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ When you add this as a connector in Claude, it walks you through a standard OAut
 | Tool | What it returns |
 |------|-----------------|
 | `get_athlete_profile` | Name, location, weight, FTP, measurement preference |
-| `get_recent_activities` | Activity list with filters: type, date range, limit (default 30, max 200) |
+| `get_recent_activities` | Activity list with filters: type, date range, limit (default 30, max 200), optional `fields` whitelist for payload reduction. Returns `{activities, count, next_after, next_before}` so paging avoids off-by-one mistakes |
 | `get_activity_details` | Full activity: laps, splits, best efforts, segment efforts, all metadata |
 | `get_activity_streams` | Per-second stream data with sport-aware defaults, optional pace_per_km / speed_kmh, optional lap_index, and optional time/distance windowing |
 | `get_activity_best_efforts` | Strava's pre-computed best efforts (1k / 1mi / 5k / 10k / half / full) for a Run, with PR ranks |
+| `get_athlete_best_efforts` | Same best efforts at a single distance (e.g. `5k`) across many Runs, sorted fastest-first. Useful for PR-over-time questions |
+| `get_athlete_summary` | Weekly or monthly rollups (count, distance, moving time, elevation, weighted avg HR, avg pace) — far cheaper than fetching the full activity list and aggregating client-side |
 | `get_activity_zones` | HR and power zone distribution, with `seconds_in_zone` summed per zone |
 | `get_activity_laps` | Manually-pressed laps for an activity |
 | `get_athlete_zones` | Your configured HR and power zone thresholds |

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ When you add this as a connector in Claude, it walks you through a standard OAut
 | `get_athlete_profile` | Name, location, weight, FTP, measurement preference |
 | `get_recent_activities` | Activity list with filters: type, date range, limit (default 30, max 200) |
 | `get_activity_details` | Full activity: laps, splits, best efforts, segment efforts, all metadata |
-| `get_activity_streams` | Raw per-second stream data — HR, pace, cadence, altitude, power, etc. |
-| `get_activity_zones` | HR and power zone distribution for an activity |
+| `get_activity_streams` | Per-second stream data with sport-aware defaults, optional pace_per_km / speed_kmh, optional lap_index, and optional time/distance windowing |
+| `get_activity_best_efforts` | Strava's pre-computed best efforts (1k / 1mi / 5k / 10k / half / full) for a Run, with PR ranks |
+| `get_activity_zones` | HR and power zone distribution, with `seconds_in_zone` summed per zone |
 | `get_activity_laps` | Manually-pressed laps for an activity |
 | `get_athlete_zones` | Your configured HR and power zone thresholds |
 | `get_athlete_stats` | Recent (4 weeks) / YTD / all-time totals by sport |
@@ -35,6 +36,16 @@ When you add this as a connector in Claude, it walks you through a standard OAut
 | `list_routes` | Your saved routes with pagination |
 | `get_route_details` | Full route metadata plus stream data (latlng, distance, altitude) |
 | `list_gear` | Bikes and shoes with mileage |
+| `health` | Diagnostics: athlete identity, last-seen Strava rate limit, cache stats, worker version |
+
+### Notes on streams
+
+- Stream defaults are sport-aware: Runs/Walks/Hikes get `time, distance, heartrate, velocity_smooth, altitude, cadence, grade_smooth`; Rides add `watts`. Override with `stream_types`.
+- `units="auto"` (the default) adds `pace_per_km` (sec/km) for runs and `speed_kmh` for rides alongside `velocity_smooth`. Pause samples come back as `null`, not `Infinity`. Pass `"raw"` to disable derivation.
+- `velocity_smooth` and `grade_smooth` are smoothed by Strava itself — the MCP does not smooth or process them further.
+- `time_range_seconds` and `distance_range_meters` slice the response server-side. The cached payload is always the full activity, so windowed queries are free after the first fetch.
+- `include_lap_index: true` adds a `lap_index` array of the same length as `time`.
+- `downsample_to_seconds` is a transport optimisation only. Per-second fidelity is the default.
 
 ### Design philosophy
 
@@ -156,8 +167,11 @@ scripts/
 ```
 
 **KV namespaces:**
-- `TOKEN_CACHE` — OAuth tokens, Strava access tokens (per-user), registered OAuth clients
-- `STREAM_CACHE` — Cached stream responses (30-day TTL)
+- `TOKEN_CACHE` — OAuth tokens, Strava access tokens (per-user), registered OAuth clients, latest Strava rate-limit snapshot, cached athlete profile for `health`
+- `STREAM_CACHE` — Cached streams (30-day TTL), activity summaries (24h TTL), laps (30-day TTL)
+
+**Logging:**
+- `LOG_LEVEL` env var (debug | info | warn | error, default `info`) controls verbosity. Logs are emitted as single-line JSON to `console.log`, viewable via `wrangler tail` or the Workers Logs UI. Auth tokens and client secrets are redacted before serialisation.
 
 **Auth:**
 - `POST /oauth/register` — Dynamic client registration (RFC 7591)

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ function rateLimitedResponse(): Response {
 function buildMcpServer(env: Env, userOAuthToken?: string): McpServer {
   const server = new McpServer({ name: "strava-mcp", version: "0.1.0" });
   const client = new StravaClient(env, userOAuthToken);
-  registerStravaTools(server, client, env.STREAM_CACHE);
+  registerStravaTools(server, client, env);
   return server;
 }
 

--- a/src/strava/activity.ts
+++ b/src/strava/activity.ts
@@ -1,0 +1,86 @@
+import type { StravaClient } from "./client.js";
+import { assertOk } from "./errors.js";
+
+export interface ActivitySummary {
+  id: number;
+  name?: string;
+  sport_type?: string;
+  type?: string;
+  distance?: number;
+  moving_time?: number;
+  elapsed_time?: number;
+  total_elevation_gain?: number;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  average_cadence?: number;
+  average_speed?: number;
+  max_speed?: number;
+  suffer_score?: number;
+  start_date_local?: string;
+  start_date?: string;
+  start_latlng?: number[];
+  end_latlng?: number[];
+  device_watts?: boolean;
+  has_heartrate?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ActivityLap {
+  id: number;
+  lap_index: number;
+  start_index?: number;
+  end_index?: number;
+  elapsed_time: number;
+  moving_time: number;
+  distance: number;
+  start_date?: string;
+  total_elevation_gain?: number;
+  average_speed?: number;
+  average_heartrate?: number;
+  [key: string]: unknown;
+}
+
+const SUMMARY_TTL_SECONDS = 24 * 60 * 60;
+const LAPS_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+// Cache key conventions, exported so other modules use the same strings.
+export const summaryCacheKey = (id: number) => `activity:${id}:summary`;
+export const lapsCacheKey = (id: number) => `laps:${id}`;
+
+// Fetches and caches the activity summary. Activities can be edited (renamed,
+// privacy changes), so a 24h TTL balances freshness with avoiding repeat
+// hits when several tools touch the same activity in one session.
+export async function fetchActivitySummary(
+  client: StravaClient,
+  cache: KVNamespace,
+  activityId: number
+): Promise<ActivitySummary> {
+  const key = summaryCacheKey(activityId);
+  const cached = await cache.get(key);
+  if (cached) {
+    return JSON.parse(cached) as ActivitySummary;
+  }
+  const res = await client.fetch(`/activities/${activityId}`);
+  assertOk(res);
+  const summary = (await res.json()) as ActivitySummary;
+  await cache.put(key, JSON.stringify(summary), { expirationTtl: SUMMARY_TTL_SECONDS });
+  return summary;
+}
+
+// Laps don't change after upload, so a long TTL is fine.
+export async function fetchActivityLaps(
+  client: StravaClient,
+  cache: KVNamespace,
+  activityId: number
+): Promise<ActivityLap[]> {
+  const key = lapsCacheKey(activityId);
+  const cached = await cache.get(key);
+  if (cached) {
+    return JSON.parse(cached) as ActivityLap[];
+  }
+  const res = await client.fetch(`/activities/${activityId}/laps`);
+  assertOk(res);
+  const laps = (await res.json()) as ActivityLap[];
+  await cache.put(key, JSON.stringify(laps), { expirationTtl: LAPS_TTL_SECONDS });
+  return laps;
+}

--- a/src/strava/client.ts
+++ b/src/strava/client.ts
@@ -1,5 +1,6 @@
 import type { Env } from "../types.js";
 import { stravaTokenCacheKey } from "../oauth.js";
+import { Logger, queryKeys } from "./logger.js";
 import type { StravaRateLimitInfo } from "./types.js";
 
 const BASE_URL = "https://www.strava.com/api/v3";
@@ -8,6 +9,10 @@ const STATIC_TOKEN_KV_KEY = "strava:access_token";
 const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
 const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
 const ERROR_BODY_PREVIEW_CHARS = 500;
+
+// KV key used by D3 to persist the latest Strava rate-limit headers seen.
+// Read by the health tool. No TTL — overwritten on every Strava response.
+export const RATE_LIMIT_KV_KEY = "rate_limit:latest";
 
 interface CachedToken {
   access_token: string;
@@ -41,13 +46,16 @@ export class StravaApiError extends Error {
 
 export class StravaClient {
   public lastRateLimitInfo: StravaRateLimitInfo | null = null;
+  private readonly logger: Logger;
 
   constructor(
     private readonly env: Env,
     // When set, tokens are looked up per-user from TOKEN_CACHE rather than
     // using the static STRAVA_REFRESH_TOKEN secret.
     private readonly userOAuthToken?: string
-  ) {}
+  ) {
+    this.logger = new Logger(env.LOG_LEVEL);
+  }
 
   async getAccessToken(): Promise<string> {
     if (this.userOAuthToken) {
@@ -173,6 +181,17 @@ export class StravaClient {
     options: RequestInit | undefined,
     isRetry: boolean
   ): Promise<Response> {
+    const method = (options?.method ?? "GET").toUpperCase();
+    const pathOnly = path.split("?")[0];
+    const startedAt = Date.now();
+
+    this.logger.debug("strava.request", {
+      method,
+      path: pathOnly,
+      query_keys: queryKeys(path),
+      is_retry: isRetry,
+    });
+
     const response = await fetch(`${BASE_URL}${path}`, {
       ...options,
       headers: {
@@ -180,11 +199,27 @@ export class StravaClient {
         Authorization: `Bearer ${token}`,
       },
     });
+    const durationMs = Date.now() - startedAt;
 
     this.lastRateLimitInfo = parseRateLimitHeaders(response.headers);
+    if (this.lastRateLimitInfo) {
+      // Fire-and-forget would risk being cancelled when the handler returns.
+      // The KV write is small and quick; awaiting it adds <10ms.
+      try {
+        await this.env.TOKEN_CACHE.put(
+          RATE_LIMIT_KV_KEY,
+          JSON.stringify({ ...this.lastRateLimitInfo, updated_at: Math.floor(Date.now() / 1000) })
+        );
+      } catch (err) {
+        this.logger.warn("strava.rate_limit_persist_failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
 
     if (response.status === 401 && !isRetry) {
       // Clear the cached access token so the next attempt does a fresh refresh
+      this.logger.info("strava.token_refresh_on_401", { method, path: pathOnly });
       const cacheKey = this.userOAuthToken
         ? stravaTokenCacheKey(this.userOAuthToken)
         : STATIC_TOKEN_KV_KEY;
@@ -196,14 +231,25 @@ export class StravaClient {
     if (!response.ok) {
       const { body } = await readErrorBody(response);
 
+      this.logger.warn("strava.response", {
+        method,
+        path: pathOnly,
+        status: response.status,
+        duration_ms: durationMs,
+        body,
+      });
+
       if (response.status === 429) {
         const resetHeader = response.headers.get("X-RateLimit-Reset");
         const retryAfterSeconds = resetHeader
           ? Math.max(1, parseInt(resetHeader, 10) - Math.floor(Date.now() / 1000))
           : 60;
+        const limitInfo = this.lastRateLimitInfo
+          ? `(usage: ${this.lastRateLimitInfo.shortTermUsage}/${this.lastRateLimitInfo.shortTermLimit} short-term, ${this.lastRateLimitInfo.dailyUsage}/${this.lastRateLimitInfo.dailyLimit} daily)`
+          : "";
         throw new StravaApiError(
           429,
-          `Strava rate limit exceeded: ${formatBodyForMessage(body)}`,
+          `Strava rate limit exceeded ${limitInfo}: ${formatBodyForMessage(body)}`.trim(),
           true,
           retryAfterSeconds,
           body
@@ -219,6 +265,18 @@ export class StravaClient {
         body
       );
     }
+
+    // Success path — log metadata only; bodies only at debug level.
+    const responseFields: Record<string, unknown> = {
+      method,
+      path: pathOnly,
+      status: response.status,
+      duration_ms: durationMs,
+    };
+    if (this.lastRateLimitInfo) {
+      responseFields.rate_limit = this.lastRateLimitInfo;
+    }
+    this.logger.info("strava.response", responseFields);
 
     return response;
   }

--- a/src/strava/client.ts
+++ b/src/strava/client.ts
@@ -7,6 +7,7 @@ const TOKEN_URL = "https://www.strava.com/oauth/token";
 const STATIC_TOKEN_KV_KEY = "strava:access_token";
 const TOKEN_EXPIRY_BUFFER_SECONDS = 300;
 const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60;
+const ERROR_BODY_PREVIEW_CHARS = 500;
 
 interface CachedToken {
   access_token: string;
@@ -30,7 +31,8 @@ export class StravaApiError extends Error {
     public readonly status: number,
     message: string,
     public readonly retryable: boolean = false,
-    public readonly retryAfterSeconds?: number
+    public readonly retryAfterSeconds?: number,
+    public readonly body?: unknown
   ) {
     super(message);
     this.name = "StravaApiError";
@@ -143,9 +145,13 @@ export class StravaClient {
     });
 
     if (!response.ok) {
+      const { body } = await readErrorBody(response);
       throw new StravaApiError(
         response.status,
-        `Token refresh failed (${response.status}): ${response.statusText}`
+        `Token refresh failed (${response.status}): ${formatBodyForMessage(body)}`,
+        false,
+        undefined,
+        body
       );
     }
 
@@ -187,24 +193,60 @@ export class StravaClient {
       return this.doFetch(path, freshToken, options, true);
     }
 
-    if (response.status === 429) {
-      const resetHeader = response.headers.get("X-RateLimit-Reset");
-      const retryAfterSeconds = resetHeader
-        ? Math.max(1, parseInt(resetHeader, 10) - Math.floor(Date.now() / 1000))
-        : 60;
-      throw new StravaApiError(429, "Strava rate limit exceeded", true, retryAfterSeconds);
-    }
+    if (!response.ok) {
+      const { body } = await readErrorBody(response);
 
-    if (response.status >= 500) {
+      if (response.status === 429) {
+        const resetHeader = response.headers.get("X-RateLimit-Reset");
+        const retryAfterSeconds = resetHeader
+          ? Math.max(1, parseInt(resetHeader, 10) - Math.floor(Date.now() / 1000))
+          : 60;
+        throw new StravaApiError(
+          429,
+          `Strava rate limit exceeded: ${formatBodyForMessage(body)}`,
+          true,
+          retryAfterSeconds,
+          body
+        );
+      }
+
+      const retryable = response.status >= 500;
       throw new StravaApiError(
         response.status,
-        `Strava server error (${response.status}): ${response.statusText}`,
-        true
+        `Strava API error (${response.status}): ${formatBodyForMessage(body)}`,
+        retryable,
+        undefined,
+        body
       );
     }
 
     return response;
   }
+}
+
+// Reads response.text() once and attempts to parse as JSON. Returns the parsed
+// body if JSON parsing succeeds, otherwise the raw text. A response body can
+// only be read once, so callers must not read again after this.
+async function readErrorBody(response: Response): Promise<{ body: unknown }> {
+  let raw: string;
+  try {
+    raw = await response.text();
+  } catch {
+    return { body: null };
+  }
+  if (!raw) return { body: null };
+  try {
+    return { body: JSON.parse(raw) };
+  } catch {
+    return { body: raw };
+  }
+}
+
+function formatBodyForMessage(body: unknown): string {
+  if (body === null || body === undefined) return "(empty body)";
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  if (text.length <= ERROR_BODY_PREVIEW_CHARS) return text;
+  return text.slice(0, ERROR_BODY_PREVIEW_CHARS) + "…";
 }
 
 function parseRateLimitHeaders(headers: Headers): StravaRateLimitInfo | null {

--- a/src/strava/errors.ts
+++ b/src/strava/errors.ts
@@ -8,7 +8,7 @@ export function assertOk(res: Response): void {
 }
 
 export type McpErrorCode =
-  | "STRAVA_RATE_LIMIT"
+  | "RATE_LIMITED"
   | "STRAVA_AUTH"
   | "STRAVA_NOT_FOUND"
   | "STRAVA_SERVER_ERROR"
@@ -41,7 +41,7 @@ export function errorResult(
 export function handleStravaError(err: unknown): McpToolResult {
   if (err instanceof StravaApiError) {
     if (err.status === 429) {
-      return errorResult("STRAVA_RATE_LIMIT", err.message, true, err.retryAfterSeconds);
+      return errorResult("RATE_LIMITED", err.message, true, err.retryAfterSeconds);
     }
     if (err.status === 401 || err.status === 403) {
       return errorResult("STRAVA_AUTH", err.message, false);

--- a/src/strava/logger.ts
+++ b/src/strava/logger.ts
@@ -1,0 +1,85 @@
+// Single-line JSON logging for Cloudflare Workers (visible in `wrangler tail`
+// and the Workers Logs UI). Never logs auth tokens or client secrets even if
+// they end up in a logged structure — values containing those keys or that
+// look like a Bearer token are redacted before serialisation.
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const SENSITIVE_KEY_PATTERN = /authorization|auth_token|client_secret|refresh_token|access_token|bearer/i;
+
+export class Logger {
+  private readonly minRank: number;
+
+  constructor(level: string | undefined) {
+    const lvl = (level ?? "info").toLowerCase() as LogLevel;
+    this.minRank = LEVEL_RANK[lvl] ?? LEVEL_RANK.info;
+  }
+
+  isDebug(): boolean {
+    return this.minRank <= LEVEL_RANK.debug;
+  }
+
+  debug(event: string, fields: Record<string, unknown> = {}): void {
+    this.log("debug", event, fields);
+  }
+  info(event: string, fields: Record<string, unknown> = {}): void {
+    this.log("info", event, fields);
+  }
+  warn(event: string, fields: Record<string, unknown> = {}): void {
+    this.log("warn", event, fields);
+  }
+  error(event: string, fields: Record<string, unknown> = {}): void {
+    this.log("error", event, fields);
+  }
+
+  private log(level: LogLevel, event: string, fields: Record<string, unknown>): void {
+    if (LEVEL_RANK[level] < this.minRank) return;
+    const payload = { level, event, ...redact(fields) };
+    try {
+      console.log(JSON.stringify(payload));
+    } catch {
+      console.log(JSON.stringify({ level, event, error: "log_serialise_failed" }));
+    }
+  }
+}
+
+// Recursively walk an object and redact any field whose key matches the
+// sensitive pattern. Strings that look like a Bearer token header are also
+// scrubbed so accidentally-logged Authorization values don't leak.
+export function redact(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return scrubBearer(value);
+  if (Array.isArray(value)) return value.map(redact);
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SENSITIVE_KEY_PATTERN.test(k)) {
+        out[k] = "[REDACTED]";
+      } else {
+        out[k] = redact(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function scrubBearer(s: string): string {
+  if (/^Bearer\s+\S+/i.test(s)) return "Bearer [REDACTED]";
+  return s;
+}
+
+// Pulls the query keys (not values) from a path so we can log what was
+// requested without leaking IDs or secret-like params.
+export function queryKeys(path: string): string[] {
+  const q = path.split("?")[1];
+  if (!q) return [];
+  return q.split("&").map((kv) => kv.split("=")[0]).filter(Boolean);
+}

--- a/src/strava/logger.ts
+++ b/src/strava/logger.ts
@@ -41,7 +41,8 @@ export class Logger {
 
   private log(level: LogLevel, event: string, fields: Record<string, unknown>): void {
     if (LEVEL_RANK[level] < this.minRank) return;
-    const payload = { level, event, ...redact(fields) };
+    const redactedFields = redact(fields) as Record<string, unknown>;
+    const payload = { level, event, ...redactedFields };
     try {
       console.log(JSON.stringify(payload));
     } catch {

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -1,3 +1,4 @@
+import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
 import type { StreamType, StreamResolution } from "./types.js";
 
@@ -32,6 +33,15 @@ const ALL_STREAM_TYPES: StreamType[] = [
   "grade_smooth",
 ];
 
+// Streams that are commonly absent on consumer GPS watches. When Strava
+// returns a 400 for the full key list, we retry without these. The activity
+// summary's `device_watts: true` flag is misleading — it indicates *estimated*
+// watts on the summary, not the existence of a per-second watts stream. A
+// 400 is the only signal we get for "this stream type isn't recorded".
+const OPTIONAL_DEVICE_STREAMS: StreamType[] = ["watts", "temp"];
+
+const STREAMS_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+
 const GAP_THRESHOLD_SECONDS = 5;
 
 interface RawStream {
@@ -52,6 +62,10 @@ interface StreamsMetadata {
   original_size: number;
   resolution_returned: string;
   downsampled_to_seconds: number | null;
+  requested_types: StreamType[];
+  returned_types: StreamType[];
+  unavailable_types: StreamType[];
+  // Legacy fields kept for backwards compat with existing consumers.
   stream_types_present: StreamType[];
   stream_types_missing: StreamType[];
   gap_count: number;
@@ -64,6 +78,11 @@ type RowsFormat = Record<string, number | number[] | boolean | null>[];
 export interface StreamsResult {
   metadata: StreamsMetadata;
   data: ArraysFormat | RowsFormat;
+}
+
+interface CachedStreams {
+  rawStreams: Record<string, RawStream>;
+  presentTypes: StreamType[];
 }
 
 export async function fetchActivityStreams(
@@ -83,45 +102,45 @@ export async function fetchActivityStreams(
     ALL_STREAM_TYPES.includes(t)
   );
 
-  // Fetch raw streams — cache by activity ID (activities are immutable)
+  // Per-activity cache (activities are immutable). The cached payload always
+  // contains the full safe stream set Strava actually returned; we filter to
+  // the user's requested types on the way out.
   const cacheKey = `streams:${activityId}:all`;
-  let rawStreams: Record<string, RawStream>;
+  const cached = await readCachedStreams(streamCache, cacheKey);
 
-  const cached = await streamCache.get(cacheKey);
+  let rawStreams: Record<string, RawStream>;
+  let presentInPayload: StreamType[];
+
   if (cached) {
-    rawStreams = JSON.parse(cached) as Record<string, RawStream>;
+    rawStreams = cached.rawStreams;
+    presentInPayload = cached.presentTypes;
   } else {
-    const keys = ALL_STREAM_TYPES.join(",");
-    const query = `?keys=${keys}&resolution=all&series_type=time`;
-    const response = await client.fetch(`/activities/${activityId}/streams${query}`);
-    if (!response.ok) {
-      throw Object.assign(new Error(`Strava API error: ${response.status}`), {
-        status: response.status,
-      });
-    }
-    const streamsArray = (await response.json()) as RawStream[];
-    rawStreams = Object.fromEntries(streamsArray.map((s) => [s.type, s]));
-    await streamCache.put(cacheKey, JSON.stringify(rawStreams), {
-      expirationTtl: 30 * 24 * 60 * 60,
+    const fetched = await fetchAllStreamsWithRetry(client, activityId);
+    rawStreams = fetched.rawStreams;
+    presentInPayload = fetched.presentTypes;
+
+    const cacheValue: CachedStreams = { rawStreams, presentTypes: presentInPayload };
+    await streamCache.put(cacheKey, JSON.stringify(cacheValue), {
+      expirationTtl: STREAMS_CACHE_TTL_SECONDS,
     });
   }
 
-  const presentTypes = requestedTypes.filter((t) => rawStreams[t] !== undefined);
-  const missingTypes = requestedTypes.filter((t) => rawStreams[t] === undefined);
+  // Anything the user asked for that isn't in the cached payload is
+  // unavailable upstream — surface it in metadata, do not re-fetch.
+  const returnedTypes = requestedTypes.filter((t) => rawStreams[t] !== undefined);
+  const unavailableTypes = requestedTypes.filter((t) => rawStreams[t] === undefined);
 
   const timeStream = rawStreams["time"];
   const originalSize = timeStream?.data?.length ?? 0;
 
-  // Detect gaps in the time stream
   const { gapCount, gapLocations } = detectGaps(timeStream?.data as number[] | undefined);
 
-  // Downsample if requested
   let outputData: Record<string, (number | number[] | boolean | null)[]>;
   if (downsampleToSeconds && downsampleToSeconds > 1 && timeStream) {
-    outputData = downsample(rawStreams, presentTypes, downsampleToSeconds);
+    outputData = downsample(rawStreams, returnedTypes, downsampleToSeconds);
   } else {
     outputData = Object.fromEntries(
-      presentTypes.map((t) => [t, rawStreams[t].data as (number | number[] | boolean | null)[]])
+      returnedTypes.map((t) => [t, rawStreams[t].data as (number | number[] | boolean | null)[]])
     );
   }
 
@@ -132,18 +151,21 @@ export async function fetchActivityStreams(
     original_size: originalSize,
     resolution_returned: resolutionReturned,
     downsampled_to_seconds: downsampleToSeconds ?? null,
-    stream_types_present: presentTypes,
-    stream_types_missing: missingTypes,
+    requested_types: requestedTypes,
+    returned_types: returnedTypes,
+    unavailable_types: unavailableTypes,
+    stream_types_present: returnedTypes,
+    stream_types_missing: unavailableTypes,
     gap_count: gapCount,
     gap_locations: gapLocations,
   };
 
   if (format === "rows") {
-    const length = outputData["time"]?.length ?? outputData[presentTypes[0]]?.length ?? 0;
+    const length = outputData["time"]?.length ?? outputData[returnedTypes[0]]?.length ?? 0;
     const rows: RowsFormat = [];
     for (let i = 0; i < length; i++) {
       const row: Record<string, number | number[] | boolean | null> = {};
-      for (const t of presentTypes) {
+      for (const t of returnedTypes) {
         row[t] = (outputData[t]?.[i] ?? null) as number | number[] | boolean | null;
       }
       rows.push(row);
@@ -152,6 +174,107 @@ export async function fetchActivityStreams(
   }
 
   return { metadata, data: outputData };
+}
+
+// Reads the streams cache, tolerating both the new {rawStreams, presentTypes}
+// shape and legacy entries that stored only the rawStreams map directly.
+async function readCachedStreams(
+  streamCache: KVNamespace,
+  cacheKey: string
+): Promise<CachedStreams | null> {
+  const raw = await streamCache.get(cacheKey);
+  if (!raw) return null;
+  const parsed = JSON.parse(raw) as unknown;
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "rawStreams" in parsed &&
+    "presentTypes" in parsed
+  ) {
+    const c = parsed as CachedStreams;
+    return { rawStreams: c.rawStreams, presentTypes: c.presentTypes };
+  }
+  // Legacy entry — derive presentTypes from the keys.
+  const legacy = parsed as Record<string, RawStream>;
+  return {
+    rawStreams: legacy,
+    presentTypes: Object.keys(legacy) as StreamType[],
+  };
+}
+
+// Fetches the full stream set from Strava, retrying once on 400 with watts
+// and temp removed (these are commonly absent on GPS watches without a power
+// meter or thermometer).
+async function fetchAllStreamsWithRetry(
+  client: StravaClient,
+  activityId: number
+): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
+  try {
+    return await fetchStreamsForKeys(client, activityId, ALL_STREAM_TYPES);
+  } catch (err) {
+    if (!(err instanceof StravaApiError) || err.status !== 400) {
+      throw err;
+    }
+    const safeKeys = ALL_STREAM_TYPES.filter((k) => !OPTIONAL_DEVICE_STREAMS.includes(k));
+    return fetchStreamsForKeys(client, activityId, safeKeys);
+  }
+}
+
+async function fetchStreamsForKeys(
+  client: StravaClient,
+  activityId: number,
+  keys: StreamType[]
+): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
+  const query = `?keys=${keys.join(",")}&resolution=all&series_type=time`;
+  const response = await client.fetch(`/activities/${activityId}/streams${query}`);
+  const streamsArray = (await response.json()) as RawStream[];
+  const rawStreams = Object.fromEntries(streamsArray.map((s) => [s.type, s]));
+  return {
+    rawStreams,
+    presentTypes: Object.keys(rawStreams) as StreamType[],
+  };
+}
+
+// Fetches segment effort streams. Strava's `/segment_efforts/:id/streams`
+// endpoint accepts a `keys` parameter and, like activities, returns 400 if
+// any requested key isn't recorded for that effort. We retry once with watts
+// and temp removed.
+export async function fetchSegmentEffortStreams(
+  client: StravaClient,
+  effortId: number,
+  keys: StreamType[]
+): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
+  try {
+    return await fetchEffortStreamsForKeys(client, effortId, keys);
+  } catch (err) {
+    if (!(err instanceof StravaApiError) || err.status !== 400) {
+      throw err;
+    }
+    const requestedOptionalKeys = keys.filter((k) => OPTIONAL_DEVICE_STREAMS.includes(k));
+    if (requestedOptionalKeys.length === 0) {
+      throw err;
+    }
+    const safeKeys = keys.filter((k) => !OPTIONAL_DEVICE_STREAMS.includes(k));
+    if (safeKeys.length === 0) {
+      throw err;
+    }
+    return fetchEffortStreamsForKeys(client, effortId, safeKeys);
+  }
+}
+
+async function fetchEffortStreamsForKeys(
+  client: StravaClient,
+  effortId: number,
+  keys: StreamType[]
+): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
+  const query = `?keys=${keys.join(",")}&resolution=all&series_type=time`;
+  const response = await client.fetch(`/segment_efforts/${effortId}/streams${query}`);
+  const json = (await response.json()) as RawStream[];
+  const rawStreams = Object.fromEntries(json.map((s) => [s.type, s]));
+  return {
+    rawStreams,
+    presentTypes: Object.keys(rawStreams) as StreamType[],
+  };
 }
 
 function detectGaps(

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -14,6 +14,11 @@ export interface StreamsParams {
   sportType?: string;
   units?: StreamsUnitsMode;
   laps?: ActivityLap[];
+  // Inclusive elapsed-second range. Both endpoints optional; omitted means
+  // unbounded on that side.
+  timeRangeSeconds?: { start?: number; end?: number };
+  // Inclusive distance range in metres along the distance stream.
+  distanceRangeMeters?: { start?: number; end?: number };
 }
 
 // Anything below this in m/s (~ 22:13 / km) is treated as stopped for the
@@ -97,6 +102,14 @@ interface GapLocation {
 
 interface StreamsMetadata {
   original_size: number;
+  // Number of samples after slicing but before downsampling.
+  sliced_size: number;
+  // Resolved [startIndex, endIndex] applied (inclusive) into the raw stream.
+  // Null when no slice was applied (whole-activity request).
+  sliced_index_range: [number, number] | null;
+  // Echo of the resolved time / distance bounds in their respective units.
+  sliced_time_seconds: { start: number; end: number } | null;
+  sliced_distance_meters: { start: number; end: number } | null;
   resolution_returned: string;
   downsampled_to_seconds: number | null;
   requested_types: StreamType[];
@@ -138,6 +151,8 @@ export async function fetchActivityStreams(
     sportType,
     units = "auto",
     laps,
+    timeRangeSeconds,
+    distanceRangeMeters,
   } = params;
 
   const effectiveStreamTypes = streamTypes ?? defaultsForSport(sportType);
@@ -176,14 +191,26 @@ export async function fetchActivityStreams(
   const timeStream = rawStreams["time"];
   const originalSize = timeStream?.data?.length ?? 0;
 
-  const { gapCount, gapLocations } = detectGaps(timeStream?.data as number[] | undefined);
+  // Resolve slice indices BEFORE gap detection / downsampling so that
+  // detection and any later derivation only see the requested window. The
+  // underlying rawStreams (and cache) are unchanged — sliceStreams returns a
+  // new map of windowed arrays.
+  const slice = computeSliceIndices(rawStreams, timeRangeSeconds, distanceRangeMeters, originalSize);
+  const slicedRawStreams =
+    slice.applied && originalSize > 0
+      ? sliceStreams(rawStreams, presentInPayload, slice.start, slice.end)
+      : rawStreams;
+  const slicedTimeStream = slicedRawStreams["time"];
+  const slicedSize = slicedTimeStream?.data?.length ?? originalSize;
+
+  const { gapCount, gapLocations } = detectGaps(slicedTimeStream?.data as number[] | undefined);
 
   let outputData: Record<string, (number | number[] | boolean | null)[]>;
-  if (downsampleToSeconds && downsampleToSeconds > 1 && timeStream) {
-    outputData = downsample(rawStreams, returnedTypes, downsampleToSeconds);
+  if (downsampleToSeconds && downsampleToSeconds > 1 && slicedTimeStream) {
+    outputData = downsample(slicedRawStreams, returnedTypes, downsampleToSeconds);
   } else {
     outputData = Object.fromEntries(
-      returnedTypes.map((t) => [t, rawStreams[t].data as (number | number[] | boolean | null)[]])
+      returnedTypes.map((t) => [t, slicedRawStreams[t].data as (number | number[] | boolean | null)[]])
     );
   }
 
@@ -214,8 +241,26 @@ export async function fetchActivityStreams(
     }
   }
 
+  const sliceTimeBounds = slice.applied
+    ? {
+        start: (timeStream?.data?.[slice.start] as number | undefined) ?? slice.start,
+        end: (timeStream?.data?.[slice.end] as number | undefined) ?? slice.end,
+      }
+    : null;
+  const distanceStream = rawStreams["distance"];
+  const sliceDistanceBounds = slice.applied && distanceStream
+    ? {
+        start: (distanceStream.data[slice.start] as number | undefined) ?? 0,
+        end: (distanceStream.data[slice.end] as number | undefined) ?? 0,
+      }
+    : null;
+
   const metadata: StreamsMetadata = {
     original_size: originalSize,
+    sliced_size: slicedSize,
+    sliced_index_range: slice.applied ? [slice.start, slice.end] : null,
+    sliced_time_seconds: sliceTimeBounds,
+    sliced_distance_meters: sliceDistanceBounds,
     resolution_returned: resolutionReturned,
     downsampled_to_seconds: downsampleToSeconds ?? null,
     requested_types: requestedTypes,
@@ -244,6 +289,90 @@ export async function fetchActivityStreams(
   }
 
   return { metadata, data: outputData };
+}
+
+// Resolves a [startIndex, endIndex] window into the raw stream from optional
+// time-second bounds, distance-metre bounds, or both. Falls back to the full
+// stream when nothing is requested. When both ranges are given, we take the
+// intersection (the tightest window). Inclusive on both ends.
+function computeSliceIndices(
+  rawStreams: Record<string, RawStream>,
+  timeRange: { start?: number; end?: number } | undefined,
+  distanceRange: { start?: number; end?: number } | undefined,
+  totalSize: number
+): { start: number; end: number; applied: boolean } {
+  if (totalSize === 0 || (!timeRange && !distanceRange)) {
+    return { start: 0, end: totalSize - 1, applied: false };
+  }
+  let start = 0;
+  let end = totalSize - 1;
+
+  const timeData = rawStreams["time"]?.data as number[] | undefined;
+  if (timeRange && timeData && timeData.length > 0) {
+    if (timeRange.start !== undefined) {
+      const found = lowerBound(timeData, timeRange.start);
+      if (found > start) start = found;
+    }
+    if (timeRange.end !== undefined) {
+      const found = upperBound(timeData, timeRange.end);
+      if (found < end) end = found;
+    }
+  }
+
+  const distanceData = rawStreams["distance"]?.data as number[] | undefined;
+  if (distanceRange && distanceData && distanceData.length > 0) {
+    if (distanceRange.start !== undefined) {
+      const found = lowerBound(distanceData, distanceRange.start);
+      if (found > start) start = found;
+    }
+    if (distanceRange.end !== undefined) {
+      const found = upperBound(distanceData, distanceRange.end);
+      if (found < end) end = found;
+    }
+  }
+
+  if (end < start) {
+    // Empty window — pin to a 1-sample slice to avoid empty arrays.
+    end = start;
+  }
+
+  return { start, end, applied: true };
+}
+
+// First index where data[i] >= target. Linear scan; streams are at most a
+// few thousand points so this is fine and avoids assuming monotonicity at
+// the binary-search level (gaps are common).
+function lowerBound(data: number[], target: number): number {
+  for (let i = 0; i < data.length; i++) {
+    if (data[i] >= target) return i;
+  }
+  return data.length - 1;
+}
+
+// Last index where data[i] <= target.
+function upperBound(data: number[], target: number): number {
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] <= target) return i;
+  }
+  return 0;
+}
+
+function sliceStreams(
+  rawStreams: Record<string, RawStream>,
+  types: StreamType[],
+  start: number,
+  end: number
+): Record<string, RawStream> {
+  const out: Record<string, RawStream> = {};
+  for (const t of types) {
+    const stream = rawStreams[t];
+    if (!stream) continue;
+    out[t] = {
+      ...stream,
+      data: stream.data.slice(start, end + 1),
+    };
+  }
+  return out;
 }
 
 // Builds an array, the same length as `time`, where each element is the

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -8,6 +8,7 @@ export interface StreamsParams {
   resolution?: StreamResolution;
   downsampleToSeconds?: number;
   format?: "arrays" | "rows";
+  sportType?: string;
 }
 
 const DEFAULT_STREAM_TYPES: StreamType[] = [
@@ -18,6 +19,32 @@ const DEFAULT_STREAM_TYPES: StreamType[] = [
   "altitude",
   "cadence",
 ];
+
+// Sport-aware default stream types. Avoids asking for watts on Runs (which
+// commonly don't have a power stream) and includes grade_smooth for outdoor
+// efforts where elevation matters. Used when the caller doesn't pass an
+// explicit stream_types list. The retry-without-watts fix in
+// fetchAllStreamsWithRetry still protects us when the device stream set
+// disagrees with what these defaults assume.
+export function defaultsForSport(sportType: string | undefined): StreamType[] {
+  switch (sportType) {
+    case "Run":
+    case "TrailRun":
+    case "Walk":
+    case "Hike":
+      return ["time", "distance", "heartrate", "velocity_smooth", "altitude", "cadence", "grade_smooth"];
+    case "Ride":
+    case "VirtualRide":
+    case "EBikeRide":
+    case "GravelRide":
+    case "MountainBikeRide":
+      return ["time", "distance", "heartrate", "velocity_smooth", "altitude", "cadence", "watts", "grade_smooth"];
+    case "Swim":
+      return ["time", "distance", "velocity_smooth", "cadence"];
+    default:
+      return DEFAULT_STREAM_TYPES;
+  }
+}
 
 const ALL_STREAM_TYPES: StreamType[] = [
   "time",
@@ -92,13 +119,15 @@ export async function fetchActivityStreams(
 ): Promise<StreamsResult> {
   const {
     activityId,
-    streamTypes = DEFAULT_STREAM_TYPES,
+    streamTypes,
     resolution = "all",
     downsampleToSeconds,
     format = "arrays",
+    sportType,
   } = params;
 
-  const requestedTypes = streamTypes.filter((t): t is StreamType =>
+  const effectiveStreamTypes = streamTypes ?? defaultsForSport(sportType);
+  const requestedTypes = effectiveStreamTypes.filter((t): t is StreamType =>
     ALL_STREAM_TYPES.includes(t)
   );
 

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -1,5 +1,6 @@
 import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
+import type { ActivityLap } from "./activity.js";
 import type { StreamType, StreamResolution } from "./types.js";
 
 export type StreamsUnitsMode = "raw" | "running" | "cycling" | "auto";
@@ -12,6 +13,7 @@ export interface StreamsParams {
   format?: "arrays" | "rows";
   sportType?: string;
   units?: StreamsUnitsMode;
+  laps?: ActivityLap[];
 }
 
 // Anything below this in m/s (~ 22:13 / km) is treated as stopped for the
@@ -135,6 +137,7 @@ export async function fetchActivityStreams(
     format = "arrays",
     sportType,
     units = "auto",
+    laps,
   } = params;
 
   const effectiveStreamTypes = streamTypes ?? defaultsForSport(sportType);
@@ -189,6 +192,13 @@ export async function fetchActivityStreams(
 
   const resolvedUnits = resolveUnitsMode(units, sportType);
   const derivedTypes: string[] = [];
+
+  if (laps && laps.length > 0 && outputData["time"]) {
+    const timeArr = outputData["time"] as (number | null)[];
+    outputData["lap_index"] = computeLapIndex(timeArr, laps);
+    derivedTypes.push("lap_index");
+  }
+
   if (resolvedUnits !== "raw" && returnedTypes.includes("velocity_smooth")) {
     const velocity = outputData["velocity_smooth"] as (number | null)[];
     if (resolvedUnits === "running") {
@@ -234,6 +244,41 @@ export async function fetchActivityStreams(
   }
 
   return { metadata, data: outputData };
+}
+
+// Builds an array, the same length as `time`, where each element is the
+// 0-based index of the lap that sample falls within. We work in elapsed
+// seconds (the time stream's units) rather than start_index/end_index from
+// Strava, because those refer to the original raw stream and don't survive
+// downsampling. Samples that don't fall in any lap come back as null —
+// shouldn't happen in practice, but better than asserting.
+export function computeLapIndex(
+  timeArr: (number | null)[],
+  laps: ActivityLap[]
+): (number | null)[] {
+  // Build [startSec, endSec] per lap from cumulative elapsed_time, sorted by
+  // lap_index so out-of-order results from Strava don't cause issues.
+  const sorted = [...laps].sort((a, b) => a.lap_index - b.lap_index);
+  const bounds: { start: number; end: number }[] = [];
+  let cursor = 0;
+  for (const lap of sorted) {
+    const start = cursor;
+    const end = start + (lap.elapsed_time ?? 0);
+    bounds.push({ start, end });
+    cursor = end;
+  }
+
+  return timeArr.map((t) => {
+    if (t === null || typeof t !== "number") return null;
+    for (let i = 0; i < bounds.length; i++) {
+      if (t >= bounds[i].start && t < bounds[i].end) return i;
+    }
+    // Edge case: the very last sample lands exactly on the final boundary.
+    if (bounds.length > 0 && t >= bounds[bounds.length - 1].end) {
+      return bounds.length - 1;
+    }
+    return null;
+  });
 }
 
 function resolveUnitsMode(

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -2,6 +2,8 @@ import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
 import type { StreamType, StreamResolution } from "./types.js";
 
+export type StreamsUnitsMode = "raw" | "running" | "cycling" | "auto";
+
 export interface StreamsParams {
   activityId: number;
   streamTypes?: StreamType[];
@@ -9,7 +11,13 @@ export interface StreamsParams {
   downsampleToSeconds?: number;
   format?: "arrays" | "rows";
   sportType?: string;
+  units?: StreamsUnitsMode;
 }
+
+// Anything below this in m/s (~ 22:13 / km) is treated as stopped for the
+// purpose of pace conversion. Without a floor, near-zero velocity samples
+// produce nonsense pace values; with one, paused sections come back as null.
+const PACE_VELOCITY_FLOOR_MS = 0.1;
 
 const DEFAULT_STREAM_TYPES: StreamType[] = [
   "time",
@@ -92,6 +100,8 @@ interface StreamsMetadata {
   requested_types: StreamType[];
   returned_types: StreamType[];
   unavailable_types: StreamType[];
+  units_mode: StreamsUnitsMode;
+  derived_types: string[];
   // Legacy fields kept for backwards compat with existing consumers.
   stream_types_present: StreamType[];
   stream_types_missing: StreamType[];
@@ -124,6 +134,7 @@ export async function fetchActivityStreams(
     downsampleToSeconds,
     format = "arrays",
     sportType,
+    units = "auto",
   } = params;
 
   const effectiveStreamTypes = streamTypes ?? defaultsForSport(sportType);
@@ -176,6 +187,23 @@ export async function fetchActivityStreams(
   const resolutionReturned =
     resolution === "all" ? "all" : (timeStream?.resolution ?? "high");
 
+  const resolvedUnits = resolveUnitsMode(units, sportType);
+  const derivedTypes: string[] = [];
+  if (resolvedUnits !== "raw" && returnedTypes.includes("velocity_smooth")) {
+    const velocity = outputData["velocity_smooth"] as (number | null)[];
+    if (resolvedUnits === "running") {
+      outputData["pace_per_km"] = velocity.map((v) =>
+        v !== null && typeof v === "number" && v > PACE_VELOCITY_FLOOR_MS ? 1000 / v : null
+      );
+      derivedTypes.push("pace_per_km");
+    } else if (resolvedUnits === "cycling") {
+      outputData["speed_kmh"] = velocity.map((v) =>
+        v !== null && typeof v === "number" ? v * 3.6 : null
+      );
+      derivedTypes.push("speed_kmh");
+    }
+  }
+
   const metadata: StreamsMetadata = {
     original_size: originalSize,
     resolution_returned: resolutionReturned,
@@ -183,6 +211,8 @@ export async function fetchActivityStreams(
     requested_types: requestedTypes,
     returned_types: returnedTypes,
     unavailable_types: unavailableTypes,
+    units_mode: resolvedUnits,
+    derived_types: derivedTypes,
     stream_types_present: returnedTypes,
     stream_types_missing: unavailableTypes,
     gap_count: gapCount,
@@ -191,10 +221,11 @@ export async function fetchActivityStreams(
 
   if (format === "rows") {
     const length = outputData["time"]?.length ?? outputData[returnedTypes[0]]?.length ?? 0;
+    const allKeys = [...returnedTypes, ...derivedTypes];
     const rows: RowsFormat = [];
     for (let i = 0; i < length; i++) {
       const row: Record<string, number | number[] | boolean | null> = {};
-      for (const t of returnedTypes) {
+      for (const t of allKeys) {
         row[t] = (outputData[t]?.[i] ?? null) as number | number[] | boolean | null;
       }
       rows.push(row);
@@ -203,6 +234,28 @@ export async function fetchActivityStreams(
   }
 
   return { metadata, data: outputData };
+}
+
+function resolveUnitsMode(
+  units: StreamsUnitsMode,
+  sportType: string | undefined
+): StreamsUnitsMode {
+  if (units !== "auto") return units;
+  switch (sportType) {
+    case "Run":
+    case "TrailRun":
+    case "Walk":
+    case "Hike":
+      return "running";
+    case "Ride":
+    case "VirtualRide":
+    case "EBikeRide":
+    case "GravelRide":
+    case "MountainBikeRide":
+      return "cycling";
+    default:
+      return "raw";
+  }
 }
 
 // Reads the streams cache, tolerating both the new {rawStreams, presentTypes}

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -145,7 +145,6 @@ export async function fetchActivityStreams(
   const {
     activityId,
     streamTypes,
-    resolution = "all",
     downsampleToSeconds,
     format = "arrays",
     sportType,
@@ -154,6 +153,9 @@ export async function fetchActivityStreams(
     timeRangeSeconds,
     distanceRangeMeters,
   } = params;
+  // The user-facing `resolution` parameter is currently a no-op: Strava only
+  // accepts low | medium | high (rejects "all") and we always fetch high to
+  // populate the cache. Reduced fidelity should use downsample_to_seconds.
 
   const effectiveStreamTypes = streamTypes ?? defaultsForSport(sportType);
   const requestedTypes = effectiveStreamTypes.filter((t): t is StreamType =>
@@ -214,8 +216,9 @@ export async function fetchActivityStreams(
     );
   }
 
-  const resolutionReturned =
-    resolution === "all" ? "all" : (timeStream?.resolution ?? "high");
+  // Strava's response carries its own `resolution` field per stream; fall
+  // back to "high" when there's no time stream to read it from.
+  const resolutionReturned = slicedTimeStream?.resolution ?? timeStream?.resolution ?? "high";
 
   const resolvedUnits = resolveUnitsMode(units, sportType);
   const derivedTypes: string[] = [];
@@ -481,7 +484,10 @@ async function fetchStreamsForKeys(
   activityId: number,
   keys: StreamType[]
 ): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
-  const query = `?keys=${keys.join(",")}&resolution=all&series_type=time`;
+  // Strava's resolution parameter accepts low | medium | high — NOT "all"
+  // (which it 400s on). "high" returns full per-second fidelity. We always
+  // fetch high here and downsample server-side per the user's request.
+  const query = `?keys=${keys.join(",")}&resolution=high&series_type=time`;
   const response = await client.fetch(`/activities/${activityId}/streams${query}`);
   const streamsArray = (await response.json()) as RawStream[];
   const rawStreams = Object.fromEntries(streamsArray.map((s) => [s.type, s]));
@@ -523,7 +529,9 @@ async function fetchEffortStreamsForKeys(
   effortId: number,
   keys: StreamType[]
 ): Promise<{ rawStreams: Record<string, RawStream>; presentTypes: StreamType[] }> {
-  const query = `?keys=${keys.join(",")}&resolution=all&series_type=time`;
+  // Same Strava limitation as activity streams: resolution must be one of
+  // low | medium | high. "high" preserves full fidelity.
+  const query = `?keys=${keys.join(",")}&resolution=high&series_type=time`;
   const response = await client.fetch(`/segment_efforts/${effortId}/streams${query}`);
   const json = (await response.json()) as RawStream[];
   const rawStreams = Object.fromEntries(json.map((s) => [s.type, s]));

--- a/src/strava/summary.ts
+++ b/src/strava/summary.ts
@@ -1,0 +1,207 @@
+import type { StravaClient } from "./client.js";
+import { assertOk } from "./errors.js";
+
+export type SummaryGranularity = "week" | "month";
+
+export interface SummaryBucket {
+  period_start: string; // YYYY-MM-DD (UTC)
+  period_end: string; // YYYY-MM-DD (UTC, inclusive)
+  count: number;
+  total_distance_m: number;
+  total_moving_time_s: number;
+  total_elapsed_time_s: number;
+  total_elevation_gain_m: number;
+  // Weighted by moving_time across the activities in the bucket. Null when
+  // no activity in the bucket reported HR.
+  avg_heartrate: number | null;
+  // total_distance_m / total_moving_time_s, expressed as seconds per km. Null
+  // when total_distance_m is zero (rest week with only stationary efforts).
+  avg_pace_per_km: number | null;
+  // Convenience field — same number expressed as km/h for ride-heavy weeks.
+  avg_speed_kmh: number | null;
+  longest_distance_m: number;
+  longest_moving_time_s: number;
+}
+
+interface ActivitySummary {
+  start_date?: string;
+  start_date_local?: string;
+  type?: string;
+  sport_type?: string;
+  distance?: number;
+  moving_time?: number;
+  elapsed_time?: number;
+  total_elevation_gain?: number;
+  average_heartrate?: number;
+}
+
+interface BucketAccumulator {
+  period_start: string;
+  period_end: string;
+  count: number;
+  total_distance: number;
+  total_moving_time: number;
+  total_elapsed_time: number;
+  total_elevation_gain: number;
+  hr_numerator: number; // sum of avg_hr * moving_time for activities with HR
+  hr_denominator: number; // sum of moving_time for activities with HR
+  longest_distance: number;
+  longest_moving_time: number;
+}
+
+const ATHLETE_ACTIVITIES_PATH = "/athlete/activities";
+const PAGE_SIZE = 200;
+// 10 pages × 200 = 2000 activities. Enough for ~10 years of running for most
+// people. If a query needs more, the caller should narrow with `after` /
+// `before`. We cap to keep one tool call from doing unbounded Strava work.
+const MAX_PAGES = 10;
+
+export async function buildAthleteSummary(
+  client: Pick<StravaClient, "fetch">,
+  opts: {
+    after?: number;
+    before?: number;
+    activityType?: string;
+    granularity: SummaryGranularity;
+  }
+): Promise<{ buckets: SummaryBucket[]; activity_count: number; pages_fetched: number }> {
+  const buckets = new Map<string, BucketAccumulator>();
+  let activityCount = 0;
+  let page = 1;
+  let pagesFetched = 0;
+
+  while (page <= MAX_PAGES) {
+    const params = new URLSearchParams({
+      page: String(page),
+      per_page: String(PAGE_SIZE),
+    });
+    if (opts.before) params.set("before", String(opts.before));
+    if (opts.after) params.set("after", String(opts.after));
+    const res = await client.fetch(`${ATHLETE_ACTIVITIES_PATH}?${params}`);
+    assertOk(res);
+    pagesFetched++;
+    const pageData = (await res.json()) as ActivitySummary[];
+    if (pageData.length === 0) break;
+
+    for (const a of pageData) {
+      if (
+        opts.activityType &&
+        a.sport_type !== opts.activityType &&
+        a.type !== opts.activityType
+      ) {
+        continue;
+      }
+      const dateStr = a.start_date_local ?? a.start_date;
+      if (!dateStr) continue;
+      const date = new Date(dateStr);
+      if (Number.isNaN(date.getTime())) continue;
+
+      const key = bucketKey(date, opts.granularity);
+      const existing = buckets.get(key.key) ?? newAccumulator(key.periodStart, key.periodEnd);
+      existing.count++;
+      existing.total_distance += a.distance ?? 0;
+      existing.total_moving_time += a.moving_time ?? 0;
+      existing.total_elapsed_time += a.elapsed_time ?? 0;
+      existing.total_elevation_gain += a.total_elevation_gain ?? 0;
+      if (typeof a.average_heartrate === "number" && (a.moving_time ?? 0) > 0) {
+        existing.hr_numerator += a.average_heartrate * (a.moving_time ?? 0);
+        existing.hr_denominator += a.moving_time ?? 0;
+      }
+      if ((a.distance ?? 0) > existing.longest_distance) {
+        existing.longest_distance = a.distance ?? 0;
+      }
+      if ((a.moving_time ?? 0) > existing.longest_moving_time) {
+        existing.longest_moving_time = a.moving_time ?? 0;
+      }
+      buckets.set(key.key, existing);
+      activityCount++;
+    }
+
+    if (pageData.length < PAGE_SIZE) break;
+    page++;
+  }
+
+  const sorted = [...buckets.values()].sort((a, b) =>
+    a.period_start.localeCompare(b.period_start)
+  );
+  return {
+    buckets: sorted.map(finalize),
+    activity_count: activityCount,
+    pages_fetched: pagesFetched,
+  };
+}
+
+function newAccumulator(period_start: string, period_end: string): BucketAccumulator {
+  return {
+    period_start,
+    period_end,
+    count: 0,
+    total_distance: 0,
+    total_moving_time: 0,
+    total_elapsed_time: 0,
+    total_elevation_gain: 0,
+    hr_numerator: 0,
+    hr_denominator: 0,
+    longest_distance: 0,
+    longest_moving_time: 0,
+  };
+}
+
+function finalize(b: BucketAccumulator): SummaryBucket {
+  const avgHr = b.hr_denominator > 0 ? b.hr_numerator / b.hr_denominator : null;
+  const avgPace =
+    b.total_distance > 0 ? b.total_moving_time / (b.total_distance / 1000) : null;
+  const avgSpeedKmh =
+    b.total_moving_time > 0 ? (b.total_distance / 1000) / (b.total_moving_time / 3600) : null;
+  return {
+    period_start: b.period_start,
+    period_end: b.period_end,
+    count: b.count,
+    total_distance_m: b.total_distance,
+    total_moving_time_s: b.total_moving_time,
+    total_elapsed_time_s: b.total_elapsed_time,
+    total_elevation_gain_m: b.total_elevation_gain,
+    avg_heartrate: avgHr,
+    avg_pace_per_km: avgPace,
+    avg_speed_kmh: avgSpeedKmh,
+    longest_distance_m: b.longest_distance,
+    longest_moving_time_s: b.longest_moving_time,
+  };
+}
+
+// Returns the bucket key plus the [period_start, period_end] dates covered.
+// Both dates are YYYY-MM-DD UTC strings; period_end is inclusive (the last
+// day in the bucket).
+export function bucketKey(
+  date: Date,
+  granularity: SummaryGranularity
+): { key: string; periodStart: string; periodEnd: string } {
+  if (granularity === "month") {
+    const y = date.getUTCFullYear();
+    const m = date.getUTCMonth();
+    const start = new Date(Date.UTC(y, m, 1));
+    const end = new Date(Date.UTC(y, m + 1, 0));
+    return {
+      key: `${y}-${String(m + 1).padStart(2, "0")}`,
+      periodStart: dateOnly(start),
+      periodEnd: dateOnly(end),
+    };
+  }
+  // ISO weeks start on Monday. JS Date.getUTCDay returns Sunday=0, Monday=1.
+  const day = date.getUTCDay();
+  const offsetToMonday = day === 0 ? 6 : day - 1;
+  const monday = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - offsetToMonday)
+  );
+  const sunday = new Date(monday);
+  sunday.setUTCDate(monday.getUTCDate() + 6);
+  return {
+    key: dateOnly(monday),
+    periodStart: dateOnly(monday),
+    periodEnd: dateOnly(sunday),
+  };
+}
+
+function dateOnly(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -157,14 +157,20 @@ export function registerStravaTools(
         .enum(["arrays", "rows"])
         .optional()
         .describe("'arrays' (default, Strava native) or 'rows' (one object per second)"),
+      units: z
+        .enum(["raw", "running", "cycling", "auto"])
+        .optional()
+        .describe(
+          "Units mode. 'auto' (default) derives from sport_type: pace_per_km for runs, speed_kmh for rides. 'raw' keeps only velocity_smooth in m/s."
+        ),
     },
-    async ({ activity_id, stream_types, resolution, downsample_to_seconds, format }) => {
+    async ({ activity_id, stream_types, resolution, downsample_to_seconds, format, units }) => {
       try {
-        // When no stream_types is supplied, fetch the activity summary so we
-        // can pick sport-aware defaults (e.g. don't ask for watts on a Run).
-        // The summary is cached, so this is cheap on repeat calls.
+        // Sport-aware defaults and 'auto' units mode both need sport_type. The
+        // summary is cached, so this is cheap on repeat calls.
+        const needSummary = !stream_types || !units || units === "auto";
         let sportType: string | undefined;
-        if (!stream_types) {
+        if (needSummary) {
           try {
             const summary = await fetchActivitySummary(client, streamCache, activity_id);
             sportType = summary.sport_type ?? summary.type;
@@ -179,6 +185,7 @@ export function registerStravaTools(
           downsampleToSeconds: downsample_to_seconds,
           format: format as "arrays" | "rows" | undefined,
           sportType,
+          units: units as "raw" | "running" | "cycling" | "auto" | undefined,
         });
         return ok(result);
       } catch (err) {

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -215,7 +215,7 @@ export function registerStravaTools(
   // Issue #7 — get_activity_zones
   server.tool(
     "get_activity_zones",
-    "HR and power zone distribution for an activity, as reported by Strava. No re-bucketing.",
+    "HR and power zone distribution for an activity, as reported by Strava. Each zone block is augmented with seconds_in_zone summed from its distribution buckets — no re-bucketing.",
     {
       activity_id: z.number().int().describe("The Strava activity ID"),
     },
@@ -223,7 +223,15 @@ export function registerStravaTools(
       try {
         const res = await client.fetch(`/activities/${activity_id}/zones`);
         assertOk(res);
-        return ok(await res.json());
+        const zones = (await res.json()) as Array<{
+          distribution_buckets?: Array<{ time?: number }>;
+          [k: string]: unknown;
+        }>;
+        const enriched = zones.map((z) => ({
+          ...z,
+          seconds_in_zone: (z.distribution_buckets ?? []).map((b) => b.time ?? 0),
+        }));
+        return ok(enriched);
       } catch (err) {
         return handleStravaError(err);
       }

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -1,11 +1,21 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StravaApiError } from "./client.js";
+import { StravaApiError, RATE_LIMIT_KV_KEY } from "./client.js";
 import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
 import { fetchActivityStreams, fetchSegmentEffortStreams } from "./streams.js";
 import { fetchActivitySummary, fetchActivityLaps } from "./activity.js";
 import type { StreamType } from "./types.js";
+import type { Env } from "../types.js";
+
+// Worker version surfaced by the health tool. Updated by hand when the
+// package version changes — Wrangler doesn't bake package.json into the
+// bundle so we keep this as a constant.
+const WORKER_VERSION = "0.1.0";
+
+const ATHLETE_PROFILE_CACHE_KEY = "health:athlete_profile";
+const ATHLETE_PROFILE_TTL_SECONDS = 24 * 60 * 60;
+const KV_LIST_LIMIT = 1000;
 
 function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
@@ -52,8 +62,10 @@ export async function fetchFilteredActivities(
 export function registerStravaTools(
   server: McpServer,
   client: StravaClient,
-  streamCache: KVNamespace
+  env: Env
 ): void {
+  const streamCache = env.STREAM_CACHE;
+  const tokenCache = env.TOKEN_CACHE;
   // Issue #3 — get_athlete_profile
   server.tool(
     "get_athlete_profile",
@@ -474,4 +486,101 @@ export function registerStravaTools(
       }
     }
   );
+
+  // D2 — health: deployment + cache + rate-limit snapshot for diagnostics.
+  server.tool(
+    "health",
+    "Worker diagnostics: athlete identity, last seen Strava rate limit, cached entry counts, and worker version. Reach for this first when something seems off.",
+    {},
+    async () => {
+      try {
+        const athlete = await readAthleteProfile(client, tokenCache);
+        const rateLimit = await readLatestRateLimit(tokenCache);
+        const cacheStats = await readCacheStats(streamCache);
+        return ok({
+          worker_version: WORKER_VERSION,
+          athlete,
+          rate_limit: rateLimit,
+          cache: cacheStats,
+        });
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
+  );
+}
+
+interface HealthAthlete {
+  id: number | null;
+  username: string | null;
+  firstname?: string;
+  lastname?: string;
+}
+
+async function readAthleteProfile(
+  client: StravaClient,
+  tokenCache: KVNamespace
+): Promise<HealthAthlete> {
+  const cached = await tokenCache.get(ATHLETE_PROFILE_CACHE_KEY);
+  if (cached) {
+    return JSON.parse(cached) as HealthAthlete;
+  }
+  const res = await client.fetch("/athlete");
+  assertOk(res);
+  const a = (await res.json()) as {
+    id?: number;
+    username?: string;
+    firstname?: string;
+    lastname?: string;
+  };
+  const profile: HealthAthlete = {
+    id: a.id ?? null,
+    username: a.username ?? null,
+    firstname: a.firstname,
+    lastname: a.lastname,
+  };
+  await tokenCache.put(ATHLETE_PROFILE_CACHE_KEY, JSON.stringify(profile), {
+    expirationTtl: ATHLETE_PROFILE_TTL_SECONDS,
+  });
+  return profile;
+}
+
+interface HealthRateLimit {
+  shortTermLimit: number;
+  shortTermUsage: number;
+  dailyLimit: number;
+  dailyUsage: number;
+  updated_at: number | null;
+}
+
+async function readLatestRateLimit(tokenCache: KVNamespace): Promise<HealthRateLimit | null> {
+  const raw = await tokenCache.get(RATE_LIMIT_KV_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as HealthRateLimit;
+  } catch {
+    return null;
+  }
+}
+
+async function readCacheStats(
+  streamCache: KVNamespace
+): Promise<{ activity_summaries: number; stream_entries: number; lap_entries: number }> {
+  // KV list returns up to 1000 keys per page. We page once: anything beyond
+  // that means the cache is large enough that the exact count doesn't matter
+  // for diagnostics. Counts saturate at KV_LIST_LIMIT.
+  const result = await streamCache.list({ limit: KV_LIST_LIMIT });
+  let activitySummaries = 0;
+  let streamEntries = 0;
+  let lapEntries = 0;
+  for (const k of result.keys) {
+    if (k.name.startsWith("streams:")) streamEntries++;
+    else if (k.name.startsWith("activity:")) activitySummaries++;
+    else if (k.name.startsWith("laps:")) lapEntries++;
+  }
+  return {
+    activity_summaries: activitySummaries,
+    stream_entries: streamEntries,
+    lap_entries: lapEntries,
+  };
 }

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -225,9 +225,11 @@ export function registerStravaTools(
         .optional()
         .describe("Stream types to fetch. Defaults to time, distance, heartrate, velocity_smooth, altitude, cadence"),
       resolution: z
-        .enum(["low", "medium", "high", "all"])
+        .enum(["low", "medium", "high"])
         .optional()
-        .describe("Data resolution. Default 'all' for maximum fidelity"),
+        .describe(
+          "Currently informational only — the server always fetches at Strava's 'high' resolution and caches the full payload. Use downsample_to_seconds to reduce sample count."
+        ),
       downsample_to_seconds: z
         .number()
         .int()
@@ -299,7 +301,7 @@ export function registerStravaTools(
         const result = await fetchActivityStreams(client, streamCache, {
           activityId: activity_id,
           streamTypes: stream_types as StreamType[] | undefined,
-          resolution: resolution as "low" | "medium" | "high" | "all" | undefined,
+          resolution: resolution as "low" | "medium" | "high" | undefined,
           downsampleToSeconds: downsample_to_seconds,
           format: format as "arrays" | "rows" | undefined,
           sportType,

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -4,6 +4,7 @@ import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
 import { fetchActivityStreams, fetchSegmentEffortStreams } from "./streams.js";
+import { fetchActivitySummary } from "./activity.js";
 import type { StreamType } from "./types.js";
 
 function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
@@ -159,12 +160,25 @@ export function registerStravaTools(
     },
     async ({ activity_id, stream_types, resolution, downsample_to_seconds, format }) => {
       try {
+        // When no stream_types is supplied, fetch the activity summary so we
+        // can pick sport-aware defaults (e.g. don't ask for watts on a Run).
+        // The summary is cached, so this is cheap on repeat calls.
+        let sportType: string | undefined;
+        if (!stream_types) {
+          try {
+            const summary = await fetchActivitySummary(client, streamCache, activity_id);
+            sportType = summary.sport_type ?? summary.type;
+          } catch {
+            // If the summary fetch fails we'll fall back to generic defaults.
+          }
+        }
         const result = await fetchActivityStreams(client, streamCache, {
           activityId: activity_id,
           streamTypes: stream_types as StreamType[] | undefined,
           resolution: resolution as "low" | "medium" | "high" | "all" | undefined,
           downsampleToSeconds: downsample_to_seconds,
           format: format as "arrays" | "rows" | undefined,
+          sportType,
         });
         return ok(result);
       } catch (err) {

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -4,7 +4,7 @@ import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
 import { fetchActivityStreams, fetchSegmentEffortStreams } from "./streams.js";
-import { fetchActivitySummary } from "./activity.js";
+import { fetchActivitySummary, fetchActivityLaps } from "./activity.js";
 import type { StreamType } from "./types.js";
 
 function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
@@ -163,8 +163,22 @@ export function registerStravaTools(
         .describe(
           "Units mode. 'auto' (default) derives from sport_type: pace_per_km for runs, speed_kmh for rides. 'raw' keeps only velocity_smooth in m/s."
         ),
+      include_lap_index: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, include a lap_index array (0-based lap each sample falls within) alongside the streams."
+        ),
     },
-    async ({ activity_id, stream_types, resolution, downsample_to_seconds, format, units }) => {
+    async ({
+      activity_id,
+      stream_types,
+      resolution,
+      downsample_to_seconds,
+      format,
+      units,
+      include_lap_index,
+    }) => {
       try {
         // Sport-aware defaults and 'auto' units mode both need sport_type. The
         // summary is cached, so this is cheap on repeat calls.
@@ -178,6 +192,9 @@ export function registerStravaTools(
             // If the summary fetch fails we'll fall back to generic defaults.
           }
         }
+        const laps = include_lap_index
+          ? await fetchActivityLaps(client, streamCache, activity_id).catch(() => undefined)
+          : undefined;
         const result = await fetchActivityStreams(client, streamCache, {
           activityId: activity_id,
           streamTypes: stream_types as StreamType[] | undefined,
@@ -186,6 +203,7 @@ export function registerStravaTools(
           format: format as "arrays" | "rows" | undefined,
           sportType,
           units: units as "raw" | "running" | "cycling" | "auto" | undefined,
+          laps,
         });
         return ok(result);
       } catch (err) {

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -5,6 +5,7 @@ import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
 import { fetchActivityStreams, fetchSegmentEffortStreams } from "./streams.js";
 import { fetchActivitySummary, fetchActivityLaps } from "./activity.js";
+import { buildAthleteSummary } from "./summary.js";
 import type { StreamType } from "./types.js";
 import type { Env } from "../types.js";
 
@@ -23,6 +24,71 @@ function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
 
 const MAX_FILTER_PAGES = 10;
 const FILTER_PAGE_SIZE = 200;
+
+// Activities, when projected with a `fields` filter, lose all type info.
+// We only need start_date for cursor computation, so this is the minimum
+// shape we depend on.
+type ActivitySummaryRow = Record<string, unknown> & { start_date?: string };
+
+async function fetchUnfilteredActivities(
+  client: Pick<StravaClient, "fetch">,
+  limit: number,
+  before: number | undefined,
+  after: number | undefined
+): Promise<ActivitySummaryRow[]> {
+  const activities: ActivitySummaryRow[] = [];
+  let page = 1;
+  while (activities.length < limit) {
+    const perPage = Math.min(200, limit - activities.length);
+    const params = new URLSearchParams({ page: String(page), per_page: String(perPage) });
+    if (before) params.set("before", String(before));
+    if (after) params.set("after", String(after));
+    const res = await client.fetch(`/athlete/activities?${params}`);
+    assertOk(res);
+    const pageData = (await res.json()) as ActivitySummaryRow[];
+    if (pageData.length === 0) break;
+    activities.push(...pageData);
+    if (pageData.length < perPage) break;
+    page++;
+  }
+  return activities.slice(0, limit);
+}
+
+function projectFields(
+  activities: ActivitySummaryRow[],
+  fields: string[] | undefined
+): Array<Record<string, unknown>> {
+  if (!fields || fields.length === 0) return activities;
+  const set = new Set(fields);
+  return activities.map((a) => {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(a)) {
+      if (set.has(k)) out[k] = a[k];
+    }
+    return out;
+  });
+}
+
+// Walks the (newest-first) activities list to find the activity with the
+// newest or oldest start_date and returns its epoch seconds for cursor use.
+// Strava's `before` / `after` filters are exclusive, so passing this value
+// directly back will skip the boundary activity rather than duplicating it.
+function cursorEpoch(activities: ActivitySummaryRow[], which: "newest" | "oldest"): number | null {
+  if (activities.length === 0) return null;
+  let extreme: number | null = null;
+  for (const a of activities) {
+    if (typeof a.start_date !== "string") continue;
+    const t = new Date(a.start_date).getTime();
+    if (Number.isNaN(t)) continue;
+    const epoch = Math.floor(t / 1000);
+    if (extreme === null) {
+      extreme = epoch;
+    } else if (which === "newest" ? epoch > extreme : epoch < extreme) {
+      extreme = epoch;
+    }
+  }
+  return extreme;
+}
 
 // Exported for unit testing. Paginates /athlete/activities in fixed-size pages
 // and accumulates activities matching activityType until limit is reached or
@@ -85,37 +151,40 @@ export function registerStravaTools(
   // Issue #4 — get_recent_activities
   server.tool(
     "get_recent_activities",
-    "Lists the athlete's activities. Filters: limit (default 30, max 200), before/after (epoch seconds), activity_type (e.g. 'Run').",
+    "Lists the athlete's activities. Filters: limit (default 30, max 200), before/after (epoch seconds), activity_type (e.g. 'Run'). Returns {activities, count, next_after, next_before}: pass next_before back as `before` to page older, or next_after as `after` to fetch newer activities later. Optional `fields` projects each activity to a subset (huge payload reduction).",
     {
       limit: z.number().int().min(1).max(200).default(30).describe("Max activities to return"),
-      before: z.number().int().optional().describe("Only return activities before this epoch timestamp"),
-      after: z.number().int().optional().describe("Only return activities after this epoch timestamp"),
+      before: z.number().int().optional().describe("Only return activities before this epoch timestamp (exclusive — Strava semantics)"),
+      after: z.number().int().optional().describe("Only return activities after this epoch timestamp (exclusive — Strava semantics)"),
       activity_type: z.string().optional().describe("Filter by type, e.g. 'Run', 'Ride'"),
+      fields: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Optional whitelist of activity fields to keep (e.g. ['id','name','start_date','distance','moving_time','average_heartrate']). Reduces payload by ~70-80%. Omit to return the full activity object."
+        ),
     },
-    async ({ limit, before, after, activity_type }) => {
+    async ({ limit, before, after, activity_type, fields }) => {
       try {
+        let activities: ActivitySummaryRow[];
         if (activity_type) {
-          return ok(
-            await fetchFilteredActivities(client, limit, activity_type, before, after)
-          );
+          activities = (await fetchFilteredActivities(
+            client,
+            limit,
+            activity_type,
+            before,
+            after
+          )) as ActivitySummaryRow[];
+        } else {
+          activities = await fetchUnfilteredActivities(client, limit, before, after);
         }
-        // Unfiltered path — unchanged: page with per_page=limit to minimise API calls
-        const activities: unknown[] = [];
-        let page = 1;
-        while (activities.length < limit) {
-          const perPage = Math.min(200, limit - activities.length);
-          const params = new URLSearchParams({ page: String(page), per_page: String(perPage) });
-          if (before) params.set("before", String(before));
-          if (after) params.set("after", String(after));
-          const res = await client.fetch(`/athlete/activities?${params}`);
-          assertOk(res);
-          const page_data = (await res.json()) as unknown[];
-          if (page_data.length === 0) break;
-          activities.push(...page_data);
-          if (page_data.length < perPage) break;
-          page++;
-        }
-        return ok(activities.slice(0, limit));
+        const projected = projectFields(activities, fields);
+        return ok({
+          activities: projected,
+          count: projected.length,
+          next_after: cursorEpoch(activities, "newest"),
+          next_before: cursorEpoch(activities, "oldest"),
+        });
       } catch (err) {
         return handleStravaError(err);
       }
@@ -143,7 +212,7 @@ export function registerStravaTools(
   // Issue #6 — get_activity_streams
   server.tool(
     "get_activity_streams",
-    "Raw per-second stream data for an activity. Returns time, distance, HR, pace, cadence, altitude, and more at full resolution. Thin pass-through — no smoothing or outlier removal.",
+    "Raw per-second stream data for an activity. Returns time, distance, HR, velocity, cadence, altitude, and more at full resolution. The MCP applies no smoothing or outlier removal — it's a thin pass-through. NOTE: velocity_smooth and grade_smooth are smoothed by Strava itself before they reach the API; that smoothing is opaque and out of this server's control. If you want the raw GPS-derived velocity, no Strava endpoint exposes it.",
     {
       activity_id: z.number().int().describe("The Strava activity ID"),
       stream_types: z
@@ -302,6 +371,38 @@ export function registerStravaTools(
         const statsRes = await client.fetch(`/athletes/${athlete.id}/stats`);
         assertOk(statsRes);
         return ok(await statsRes.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
+  );
+
+  // get_athlete_summary — weekly or monthly rollups across many activities,
+  // returned as a single small payload. Recommended starting point for
+  // trend questions ("how have my weekly volumes changed", "which months
+  // have my best average pace"). Hard-capped at ~2000 activities per call;
+  // narrow with `after` / `before` for longer histories.
+  server.tool(
+    "get_athlete_summary",
+    "Aggregated rollups (count, distance, moving time, elevation, weighted avg HR, avg pace) bucketed by week or month. Pure arithmetic over Strava activity-summary fields — no smoothing, no opinions. Far cheaper than fetching the full activity list and aggregating client-side. Capped at ~2000 activities per call; narrow with after/before for longer windows.",
+    {
+      after: z.number().int().optional().describe("Epoch seconds — activities on or after this time"),
+      before: z.number().int().optional().describe("Epoch seconds — activities before this time"),
+      activity_type: z.string().optional().describe("Filter by sport_type/type, e.g. 'Run' or 'Ride'"),
+      granularity: z
+        .enum(["week", "month"])
+        .default("month")
+        .describe("Bucket size. 'week' is Monday-start ISO weeks; 'month' is calendar month."),
+    },
+    async ({ after, before, activity_type, granularity }) => {
+      try {
+        const summary = await buildAthleteSummary(client, {
+          after,
+          before,
+          activityType: activity_type,
+          granularity,
+        });
+        return ok(summary);
       } catch (err) {
         return handleStravaError(err);
       }
@@ -509,6 +610,44 @@ export function registerStravaTools(
     }
   );
 
+  // get_athlete_best_efforts — scans Run activities in the window and pulls
+  // out Strava's best_efforts entries for a single distance ("5k", "10k",
+  // etc). Useful for PR-trend-over-time questions. Caches the per-activity
+  // detail so a follow-up query in a different window is cheap.
+  server.tool(
+    "get_athlete_best_efforts",
+    "Strava-computed best efforts for a single distance ('1k' | '1 mile' | '5k' | '10k' | 'Half-Marathon' | 'Marathon') across many Run activities. Returns a list sorted fastest-first. Hits each Run's detail endpoint, so it can issue many Strava calls — use after/before to keep the window narrow.",
+    {
+      distance: z
+        .string()
+        .describe(
+          "Strava best-effort name to filter on, e.g. '5k', '10k', 'Half-Marathon'. Match is case-insensitive and exact on Strava's name field."
+        ),
+      after: z.number().int().optional().describe("Epoch seconds — activities on or after this time"),
+      before: z.number().int().optional().describe("Epoch seconds — activities before this time"),
+      max_activities: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .default(200)
+        .describe("Cap on Run activities scanned. Defaults to 200 to bound Strava API hits."),
+    },
+    async ({ distance, after, before, max_activities }) => {
+      try {
+        const result = await collectAthleteBestEfforts(client, streamCache, {
+          distance,
+          after,
+          before,
+          maxActivities: max_activities,
+        });
+        return ok(result);
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
+  );
+
   // get_activity_best_efforts — projects the Strava-computed best_efforts
   // array off the activity detail. Strava already calculates 1k / 1mi / 5k /
   // 10k / half / full PRs for every Run; this tool returns just that subset
@@ -609,6 +748,83 @@ async function readLatestRateLimit(tokenCache: KVNamespace): Promise<HealthRateL
   } catch {
     return null;
   }
+}
+
+interface BestEffortRow {
+  activity_id: number;
+  activity_name?: string;
+  start_date_local?: string;
+  name: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  pr_rank: number | null;
+  is_kom: boolean;
+  effort_id?: number;
+}
+
+async function collectAthleteBestEfforts(
+  client: StravaClient,
+  streamCache: KVNamespace,
+  opts: {
+    distance: string;
+    after?: number;
+    before?: number;
+    maxActivities: number;
+  }
+): Promise<{
+  distance: string;
+  results: BestEffortRow[];
+  activities_scanned: number;
+  activities_with_best_efforts: number;
+}> {
+  // 1. Page through /athlete/activities filtering to Run.
+  const runs = (await fetchFilteredActivities(
+    client,
+    opts.maxActivities,
+    "Run",
+    opts.before,
+    opts.after
+  )) as Array<{ id: number }>;
+
+  // 2. For each Run, hit /activities/{id} (cached) and pluck best_efforts.
+  const target = opts.distance.toLowerCase();
+  const results: BestEffortRow[] = [];
+  let withBest = 0;
+  for (const r of runs) {
+    let detail;
+    try {
+      detail = await fetchActivitySummary(client, streamCache, r.id);
+    } catch {
+      // Individual activity fetch failures are non-fatal for this rollup.
+      continue;
+    }
+    const efforts = (detail.best_efforts as Array<Record<string, unknown>> | undefined) ?? [];
+    if (efforts.length > 0) withBest++;
+    for (const e of efforts) {
+      const name = (e.name as string | undefined) ?? "";
+      if (name.toLowerCase() !== target) continue;
+      results.push({
+        activity_id: r.id,
+        activity_name: detail.name,
+        start_date_local: detail.start_date_local,
+        name,
+        distance: (e.distance as number | undefined) ?? 0,
+        moving_time: (e.moving_time as number | undefined) ?? 0,
+        elapsed_time: (e.elapsed_time as number | undefined) ?? 0,
+        pr_rank: (e.pr_rank as number | null | undefined) ?? null,
+        is_kom: Boolean(e.is_kom),
+        effort_id: e.id as number | undefined,
+      });
+    }
+  }
+  results.sort((a, b) => a.moving_time - b.moving_time);
+  return {
+    distance: opts.distance,
+    results,
+    activities_scanned: runs.length,
+    activities_with_best_efforts: withBest,
+  };
 }
 
 async function readCacheStats(

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -181,6 +181,24 @@ export function registerStravaTools(
         .describe(
           "If true, include a lap_index array (0-based lap each sample falls within) alongside the streams."
         ),
+      time_range_seconds: z
+        .object({
+          start: z.number().optional(),
+          end: z.number().optional(),
+        })
+        .optional()
+        .describe(
+          "Optional inclusive window in elapsed seconds. Use to pull only a portion of the activity (e.g. last 5 minutes). Either bound may be omitted."
+        ),
+      distance_range_meters: z
+        .object({
+          start: z.number().optional(),
+          end: z.number().optional(),
+        })
+        .optional()
+        .describe(
+          "Optional inclusive window along the distance stream in metres (e.g. {start: 10000, end: 15000} for kilometres 10–15). Either bound may be omitted."
+        ),
     },
     async ({
       activity_id,
@@ -190,6 +208,8 @@ export function registerStravaTools(
       format,
       units,
       include_lap_index,
+      time_range_seconds,
+      distance_range_meters,
     }) => {
       try {
         // Sport-aware defaults and 'auto' units mode both need sport_type. The
@@ -216,6 +236,8 @@ export function registerStravaTools(
           sportType,
           units: units as "raw" | "running" | "cycling" | "auto" | undefined,
           laps,
+          timeRangeSeconds: time_range_seconds,
+          distanceRangeMeters: distance_range_meters,
         });
         return ok(result);
       } catch (err) {
@@ -481,6 +503,32 @@ export function registerStravaTools(
         const res = await client.fetch(`/activities/${activity_id}/laps`);
         assertOk(res);
         return ok(await res.json());
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
+  );
+
+  // get_activity_best_efforts — projects the Strava-computed best_efforts
+  // array off the activity detail. Strava already calculates 1k / 1mi / 5k /
+  // 10k / half / full PRs for every Run; this tool returns just that subset
+  // so consumers don't have to pull the full activity payload.
+  server.tool(
+    "get_activity_best_efforts",
+    "Returns Strava's pre-computed best efforts (1k, 1mi, 5k, 10k, half marathon, marathon) for a Run activity, including pr_rank when the effort was a PR. Rides have no best_efforts; the response will be empty for those.",
+    {
+      activity_id: z.number().int().describe("The Strava activity ID"),
+    },
+    async ({ activity_id }) => {
+      try {
+        const summary = await fetchActivitySummary(client, streamCache, activity_id);
+        const efforts = (summary["best_efforts"] as unknown[]) ?? [];
+        return ok({
+          activity_id,
+          sport_type: summary.sport_type ?? summary.type,
+          start_date_local: summary.start_date_local,
+          best_efforts: efforts,
+        });
       } catch (err) {
         return handleStravaError(err);
       }

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StravaApiError } from "./client.js";
 import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
-import { fetchActivityStreams } from "./streams.js";
+import { fetchActivityStreams, fetchSegmentEffortStreams } from "./streams.js";
 import type { StreamType } from "./types.js";
 
 function ok(data: unknown): { content: [{ type: "text"; text: string }] } {
@@ -286,21 +287,22 @@ export function registerStravaTools(
     },
     async ({ effort_id, stream_types }) => {
       try {
-        const keys = (stream_types ?? ["time", "distance", "altitude", "latlng"]).join(",");
-        const res = await client.fetch(
-          `/segment_efforts/${effort_id}/streams?keys=${keys}&resolution=all&series_type=time`
+        const requested = (stream_types ?? ["time", "distance", "altitude", "latlng"]) as StreamType[];
+        const { rawStreams, presentTypes } = await fetchSegmentEffortStreams(
+          client,
+          effort_id,
+          requested
         );
-        assertOk(res);
-        const streamsArray = (await res.json()) as { type: string; data: unknown[] }[];
-        const present = streamsArray.map((s) => s.type);
-        const requested = stream_types ?? ["time", "distance", "altitude", "latlng"];
-        const missing = requested.filter((t) => !present.includes(t));
+        const missing = requested.filter((t) => !presentTypes.includes(t));
         return ok({
           metadata: {
-            stream_types_present: present,
+            requested_types: requested,
+            returned_types: presentTypes,
+            unavailable_types: missing,
+            stream_types_present: presentTypes,
             stream_types_missing: missing,
           },
-          data: Object.fromEntries(streamsArray.map((s) => [s.type, s.data])),
+          data: Object.fromEntries(presentTypes.map((t) => [t, rawStreams[t].data])),
         });
       } catch (err) {
         return handleStravaError(err);
@@ -368,15 +370,21 @@ export function registerStravaTools(
     },
     async ({ route_id }) => {
       try {
-        const [routeRes, streamsRes] = await Promise.all([
-          client.fetch(`/routes/${route_id}`),
-          client.fetch(`/routes/${route_id}/streams`),
-        ]);
+        const routeRes = await client.fetch(`/routes/${route_id}`);
         assertOk(routeRes);
         const route = await routeRes.json();
+        // /routes/:id/streams returns a fixed set (latlng, distance, altitude)
+        // and doesn't accept a `keys` parameter, so it shouldn't 400 from
+        // missing keys. It can still 403/404 on routes without stream data —
+        // tolerate that and return the route with null streams.
         let streams: unknown = null;
-        if (streamsRes.ok) {
-          streams = await streamsRes.json();
+        try {
+          const streamsRes = await client.fetch(`/routes/${route_id}/streams`);
+          if (streamsRes.ok) {
+            streams = await streamsRes.json();
+          }
+        } catch (err) {
+          if (!(err instanceof StravaApiError)) throw err;
         }
         return ok({ route, streams });
       } catch (err) {

--- a/src/strava/types.ts
+++ b/src/strava/types.ts
@@ -11,7 +11,7 @@ export type StreamType =
   | "moving"
   | "grade_smooth";
 
-export type StreamResolution = "low" | "medium" | "high" | "all";
+export type StreamResolution = "low" | "medium" | "high";
 
 export interface StravaStream {
   type: StreamType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,4 +6,5 @@ export interface Env {
   STRAVA_CLIENT_ID: string;
   STRAVA_CLIENT_SECRET: string;
   STRAVA_REFRESH_TOKEN: string;
+  LOG_LEVEL?: string;
 }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -12,7 +12,7 @@ describe("errorResult", () => {
   });
 
   it("includes retry_after_seconds when provided", () => {
-    const result = errorResult("STRAVA_RATE_LIMIT", "Rate limited", true, 45);
+    const result = errorResult("RATE_LIMITED", "Rate limited", true, 45);
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.error.retry_after_seconds).toBe(45);
     expect(parsed.error.retryable).toBe(true);
@@ -26,11 +26,11 @@ describe("errorResult", () => {
 });
 
 describe("handleStravaError", () => {
-  it("maps 429 to STRAVA_RATE_LIMIT with retryable=true", () => {
+  it("maps 429 to RATE_LIMITED with retryable=true", () => {
     const err = new StravaApiError(429, "Rate limit exceeded", true, 30);
     const result = handleStravaError(err);
     const parsed = JSON.parse(result.content[0].text);
-    expect(parsed.error.code).toBe("STRAVA_RATE_LIMIT");
+    expect(parsed.error.code).toBe("RATE_LIMITED");
     expect(parsed.error.retryable).toBe(true);
     expect(parsed.error.retry_after_seconds).toBe(30);
   });

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Logger, redact, queryKeys } from "../src/strava/logger.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("redact", () => {
+  it("redacts sensitive keys recursively", () => {
+    const out = redact({
+      authorization: "Bearer abc",
+      nested: { client_secret: "shh", access_token: "x" },
+      ok: "fine",
+    }) as Record<string, unknown>;
+    expect(out.authorization).toBe("[REDACTED]");
+    expect((out.nested as Record<string, unknown>).client_secret).toBe("[REDACTED]");
+    expect((out.nested as Record<string, unknown>).access_token).toBe("[REDACTED]");
+    expect(out.ok).toBe("fine");
+  });
+
+  it("scrubs Bearer tokens that appear as values", () => {
+    const out = redact({ headers: { Authorization: "Bearer my-token-here" } }) as {
+      headers: Record<string, string>;
+    };
+    // Whole field redacted by key match
+    expect(out.headers.Authorization).toBe("[REDACTED]");
+  });
+
+  it("scrubs Bearer tokens in non-sensitive keys too", () => {
+    expect(redact("Bearer leaked")).toBe("Bearer [REDACTED]");
+  });
+
+  it("handles arrays and primitives", () => {
+    expect(redact([1, 2, "three"])).toEqual([1, 2, "three"]);
+    expect(redact(null)).toBe(null);
+    expect(redact(undefined)).toBe(undefined);
+    expect(redact(42)).toBe(42);
+  });
+});
+
+describe("queryKeys", () => {
+  it("extracts only keys, not values", () => {
+    expect(queryKeys("/activities/1/streams?keys=time,heartrate&resolution=all")).toEqual([
+      "keys",
+      "resolution",
+    ]);
+  });
+
+  it("returns empty for paths without query", () => {
+    expect(queryKeys("/athlete")).toEqual([]);
+  });
+});
+
+describe("Logger", () => {
+  it("emits single-line JSON at the configured level", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const log = new Logger("info");
+    log.info("strava.response", { status: 200, duration_ms: 42 });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const line = spy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(line);
+    expect(parsed).toMatchObject({ level: "info", event: "strava.response", status: 200, duration_ms: 42 });
+  });
+
+  it("suppresses debug logs at info level", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const log = new Logger("info");
+    log.debug("strava.request", { path: "/athlete" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("emits debug logs when level is debug", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const log = new Logger("debug");
+    log.debug("strava.request", { path: "/athlete" });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("redacts sensitive fields before serialising", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const log = new Logger("info");
+    log.info("strava.request", {
+      headers: { Authorization: "Bearer secret-value" },
+      body: { client_secret: "very-secret" },
+    });
+    const line = spy.mock.calls[0][0] as string;
+    expect(line).not.toContain("secret-value");
+    expect(line).not.toContain("very-secret");
+  });
+
+  it("falls back to info when LOG_LEVEL is missing or invalid", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const log = new Logger(undefined);
+    log.info("test", {});
+    log.debug("test", {}); // suppressed
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/strava-client.test.ts
+++ b/test/strava-client.test.ts
@@ -316,4 +316,77 @@ describe("StravaClient.fetch", () => {
     expect(err.retryAfterSeconds).toBe(30);
     expect((err.body as { message: string }).message).toBe("Rate Limit Exceeded");
   });
+
+  // ---------------------------------------------------------------------------
+  // D1 — structured logging from the client wrapper
+  // ---------------------------------------------------------------------------
+
+  it("logs status and duration on successful calls", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(apiResponse({}, 200, rateLimitHeaders())));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await client.fetch("/athlete");
+
+    const lines = logSpy.mock.calls.map((c) => c[0] as string).filter((l) => typeof l === "string");
+    const responseLine = lines.find((l) => l.includes("strava.response"));
+    expect(responseLine).toBeDefined();
+    const parsed = JSON.parse(responseLine!);
+    expect(parsed.status).toBe(200);
+    expect(typeof parsed.duration_ms).toBe("number");
+    expect(parsed.method).toBe("GET");
+  });
+
+  it("logs the parsed body on non-OK responses", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    const errorBody = { message: "Bad", errors: [{ code: "invalid", field: "watts" }] };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(apiResponse(errorBody, 400)));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await client.fetch("/activities/1/streams").catch(() => {});
+
+    const lines = logSpy.mock.calls.map((c) => c[0] as string);
+    const errorLine = lines.find((l) => l.includes("strava.response") && l.includes("400"));
+    expect(errorLine).toBeDefined();
+    expect(errorLine).toContain("invalid");
+    expect(errorLine).toContain("watts");
+  });
+
+  it("does not log auth tokens or client secrets even if accidentally included", async () => {
+    const cachedToken = JSON.stringify({ access_token: "leak-token-12345", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const env = makeEnv(kv);
+    env.STRAVA_CLIENT_SECRET = "leak-secret-67890";
+    const client = new StravaClient(env);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(apiResponse({}, 200)));
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await client.fetch("/athlete");
+
+    const allOutput = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(allOutput).not.toContain("leak-token-12345");
+    expect(allOutput).not.toContain("leak-secret-67890");
+  });
+
+  // ---------------------------------------------------------------------------
+  // D3 — rate limit persistence to KV
+  // ---------------------------------------------------------------------------
+
+  it("persists rate-limit headers to TOKEN_CACHE under rate_limit:latest", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(apiResponse({}, 200, rateLimitHeaders())));
+
+    await client.fetch("/athlete");
+
+    expect(kv.put).toHaveBeenCalledWith(
+      "rate_limit:latest",
+      expect.stringContaining('"shortTermLimit":100')
+    );
+  });
 });

--- a/test/strava-client.test.ts
+++ b/test/strava-client.test.ts
@@ -221,7 +221,7 @@ describe("StravaClient.fetch", () => {
     );
   });
 
-  it("throws on 401 without retrying a second time", async () => {
+  it("throws StravaApiError on 401 after a retry without retrying again", async () => {
     const cachedToken = JSON.stringify({ access_token: "stale-token", expires_at: FUTURE_EXPIRES_AT });
     const kv = makeKv({ "strava:access_token": cachedToken });
     const client = new StravaClient(makeEnv(kv));
@@ -233,9 +233,87 @@ describe("StravaClient.fetch", () => {
 
     vi.stubGlobal("fetch", mockFetch);
 
-    // On second 401 (isRetry=true) the response is returned as-is (not thrown)
-    const response = await client.fetch("/athlete");
-    expect(response.status).toBe(401);
+    const err = await client.fetch("/athlete").catch((e) => e);
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect(err.status).toBe(401);
     expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  // ---------------------------------------------------------------------------
+  // A2 — upstream Strava error bodies are surfaced
+  // ---------------------------------------------------------------------------
+
+  it("includes parsed JSON body on a non-OK response", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    const errorBody = {
+      message: "Bad Request",
+      errors: [{ resource: "Stream", field: "watts", code: "invalid" }],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(apiResponse(errorBody, 400)));
+
+    const err = await client.fetch("/activities/1/streams").catch((e) => e);
+
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect(err.status).toBe(400);
+    expect(err.body).toEqual(errorBody);
+    expect(err.message).toContain("watts");
+    expect(err.message).toContain("invalid");
+  });
+
+  it("includes raw text body when response body is not JSON", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("Internal Server Error — html page here", { status: 502 })
+      )
+    );
+
+    const err = await client.fetch("/athlete").catch((e) => e);
+
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect(err.status).toBe(502);
+    expect(err.body).toBe("Internal Server Error — html page here");
+    expect(err.message).toContain("Internal Server Error");
+  });
+
+  it("does not crash when error body is empty", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 403 })));
+
+    const err = await client.fetch("/athlete").catch((e) => e);
+
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect(err.status).toBe(403);
+  });
+
+  it("includes parsed body on 429 rate limit responses", async () => {
+    const cachedToken = JSON.stringify({ access_token: "cached-token", expires_at: FUTURE_EXPIRES_AT });
+    const kv = makeKv({ "strava:access_token": cachedToken });
+    const client = new StravaClient(makeEnv(kv));
+    const resetAt = NOW_SECONDS + 30;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        apiResponse(
+          { message: "Rate Limit Exceeded", errors: [] },
+          429,
+          { "X-RateLimit-Reset": String(resetAt) }
+        )
+      )
+    );
+
+    const err = await client.fetch("/athlete").catch((e) => e);
+
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect(err.status).toBe(429);
+    expect(err.retryAfterSeconds).toBe(30);
+    expect((err.body as { message: string }).message).toBe("Rate Limit Exceeded");
   });
 });

--- a/test/streams-extras.test.ts
+++ b/test/streams-extras.test.ts
@@ -186,6 +186,107 @@ describe("computeLapIndex", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Stream windowing — time_range and distance_range
+// ---------------------------------------------------------------------------
+
+describe("fetchActivityStreams with time/distance windowing", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function streams20s() {
+    const time = Array.from({ length: 20 }, (_, i) => i);
+    const distance = time.map((t) => t * 5); // 5 m/s
+    const heartrate = time.map((t) => 130 + t);
+    return [
+      { type: "time", data: time, series_type: "time", original_size: 20, resolution: "high" },
+      { type: "distance", data: distance, series_type: "time", original_size: 20, resolution: "high" },
+      { type: "heartrate", data: heartrate, series_type: "time", original_size: 20, resolution: "high" },
+    ];
+  }
+
+  it("slices by time_range_seconds inclusively on both ends", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "heartrate"],
+      timeRangeSeconds: { start: 5, end: 9 },
+    });
+    const data = result.data as Record<string, unknown[]>;
+    expect(data.time).toEqual([5, 6, 7, 8, 9]);
+    expect(data.heartrate).toEqual([135, 136, 137, 138, 139]);
+    expect(result.metadata.original_size).toBe(20);
+    expect(result.metadata.sliced_size).toBe(5);
+    expect(result.metadata.sliced_index_range).toEqual([5, 9]);
+    expect(result.metadata.sliced_time_seconds).toEqual({ start: 5, end: 9 });
+  });
+
+  it("slices by distance_range_meters", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "distance"],
+      distanceRangeMeters: { start: 25, end: 50 },
+    });
+    const data = result.data as Record<string, unknown[]>;
+    // distance 25..50 corresponds to indices 5..10 (distance = i*5)
+    expect(data.distance).toEqual([25, 30, 35, 40, 45, 50]);
+    expect(result.metadata.sliced_distance_meters).toEqual({ start: 25, end: 50 });
+  });
+
+  it("intersects time and distance ranges (tightest window wins)", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time"],
+      timeRangeSeconds: { start: 5 },
+      distanceRangeMeters: { end: 50 }, // index 10
+    });
+    const data = result.data as Record<string, unknown[]>;
+    expect(data.time).toEqual([5, 6, 7, 8, 9, 10]);
+  });
+
+  it("treats omitted bounds as unbounded on that side", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time"],
+      timeRangeSeconds: { start: 18 }, // open-ended end
+    });
+    const data = result.data as Record<string, unknown[]>;
+    expect(data.time).toEqual([18, 19]);
+  });
+
+  it("downsampling operates on the sliced window, not the whole activity", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "heartrate"],
+      timeRangeSeconds: { start: 0, end: 9 },
+      downsampleToSeconds: 5,
+    });
+    const data = result.data as Record<string, unknown[]>;
+    // Two buckets within the window: 0-4 and 5-9
+    expect(data.time).toHaveLength(2);
+  });
+
+  it("reports null slice metadata when no window was requested", async () => {
+    const client = makeClient(streams20s());
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time"],
+    });
+    expect(result.metadata.sliced_index_range).toBeNull();
+    expect(result.metadata.sliced_time_seconds).toBeNull();
+    expect(result.metadata.sliced_distance_meters).toBeNull();
+  });
+});
+
 describe("fetchActivityStreams with laps", () => {
   afterEach(() => vi.restoreAllMocks());
 

--- a/test/streams-extras.test.ts
+++ b/test/streams-extras.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  fetchActivityStreams,
+  defaultsForSport,
+  computeLapIndex,
+} from "../src/strava/streams.js";
+import type { StravaClient } from "../src/strava/client.js";
+import type { ActivityLap } from "../src/strava/activity.js";
+
+function makeKv(initial: Record<string, string> = {}): KVNamespace {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => { store.set(key, value); }),
+    delete: vi.fn(async (key: string) => { store.delete(key); }),
+    list: vi.fn(async () => ({ keys: [], list_complete: true, cursor: "" })),
+    getWithMetadata: vi.fn(async () => ({ value: null, metadata: null })),
+  } as unknown as KVNamespace;
+}
+
+function makeClient(streamsBody: unknown): StravaClient {
+  return {
+    fetch: vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(streamsBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    ),
+    lastRateLimitInfo: null,
+  } as unknown as StravaClient;
+}
+
+// ---------------------------------------------------------------------------
+// C1 — defaultsForSport
+// ---------------------------------------------------------------------------
+
+describe("defaultsForSport", () => {
+  it("excludes watts for Run", () => {
+    const d = defaultsForSport("Run");
+    expect(d).not.toContain("watts");
+    expect(d).toContain("heartrate");
+    expect(d).toContain("grade_smooth");
+  });
+
+  it("includes watts for Ride", () => {
+    const d = defaultsForSport("Ride");
+    expect(d).toContain("watts");
+    expect(d).toContain("cadence");
+  });
+
+  it("returns swim-friendly subset for Swim", () => {
+    const d = defaultsForSport("Swim");
+    expect(d).not.toContain("altitude");
+    expect(d).not.toContain("heartrate");
+    expect(d).toContain("velocity_smooth");
+    expect(d).toContain("cadence");
+  });
+
+  it("falls back to generic defaults for unknown sport types", () => {
+    const generic = defaultsForSport(undefined);
+    const unknown = defaultsForSport("Snowboard");
+    expect(unknown).toEqual(generic);
+  });
+
+  it("treats trail runs and walks like runs", () => {
+    expect(defaultsForSport("TrailRun")).not.toContain("watts");
+    expect(defaultsForSport("Walk")).not.toContain("watts");
+    expect(defaultsForSport("Hike")).not.toContain("watts");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C2 — pace conversion
+// ---------------------------------------------------------------------------
+
+describe("pace conversion (units = running)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("produces null for zero or near-zero velocity samples (not Infinity)", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2, 3, 4], series_type: "time", original_size: 5, resolution: "high" },
+      { type: "velocity_smooth", data: [3.0, 0, 0.05, 2.5, 4.0], series_type: "time", original_size: 5, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "velocity_smooth"],
+      units: "running",
+    });
+    const data = result.data as Record<string, (number | null)[]>;
+    expect(data.pace_per_km).toBeDefined();
+    expect(data.pace_per_km[0]).toBeCloseTo(1000 / 3.0, 4);
+    expect(data.pace_per_km[1]).toBeNull();
+    expect(data.pace_per_km[2]).toBeNull();
+    // No infinities anywhere
+    for (const v of data.pace_per_km) {
+      expect(v === Infinity || v === -Infinity).toBe(false);
+    }
+    expect(result.metadata.derived_types).toContain("pace_per_km");
+    expect(result.metadata.units_mode).toBe("running");
+  });
+
+  it("produces speed_kmh in cycling mode", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+      { type: "velocity_smooth", data: [10, 5, 0], series_type: "time", original_size: 3, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "velocity_smooth"],
+      units: "cycling",
+    });
+    const data = result.data as Record<string, (number | null)[]>;
+    expect(data.speed_kmh).toEqual([36, 18, 0]);
+  });
+
+  it("auto mode resolves to running for Run sport_type", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+      { type: "velocity_smooth", data: [3, 3, 3], series_type: "time", original_size: 3, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "velocity_smooth"],
+      units: "auto",
+      sportType: "Run",
+    });
+    expect(result.metadata.units_mode).toBe("running");
+    expect((result.data as Record<string, unknown>)["pace_per_km"]).toBeDefined();
+  });
+
+  it("raw mode produces no derived fields", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+      { type: "velocity_smooth", data: [3, 3, 3], series_type: "time", original_size: 3, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time", "velocity_smooth"],
+      units: "raw",
+    });
+    expect(result.metadata.derived_types).toEqual([]);
+    const data = result.data as Record<string, unknown>;
+    expect(data.pace_per_km).toBeUndefined();
+    expect(data.speed_kmh).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// C3 — lap_index
+// ---------------------------------------------------------------------------
+
+describe("computeLapIndex", () => {
+  const laps: ActivityLap[] = [
+    { id: 1, lap_index: 1, elapsed_time: 5, moving_time: 5, distance: 10 },
+    { id: 2, lap_index: 2, elapsed_time: 5, moving_time: 5, distance: 10 },
+  ];
+
+  it("assigns the correct lap to each time sample", () => {
+    const time = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const out = computeLapIndex(time, laps);
+    expect(out).toEqual([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]);
+  });
+
+  it("returns an array of the same length as time", () => {
+    const time = Array.from({ length: 100 }, (_, i) => i / 10);
+    const out = computeLapIndex(time, laps);
+    expect(out).toHaveLength(100);
+  });
+
+  it("treats null time samples as null lap", () => {
+    const out = computeLapIndex([null, 0, null, 6], laps);
+    expect(out).toEqual([null, 0, null, 1]);
+  });
+
+  it("includes the very last sample on the final boundary in the last lap", () => {
+    const out = computeLapIndex([10], laps);
+    expect(out).toEqual([1]);
+  });
+});
+
+describe("fetchActivityStreams with laps", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("emits lap_index when laps are provided", async () => {
+    const streams = [
+      { type: "time", data: [0, 1, 2, 3, 4, 5], series_type: "time", original_size: 6, resolution: "high" },
+    ];
+    const client = makeClient(streams);
+    const kv = makeKv();
+    const laps: ActivityLap[] = [
+      { id: 1, lap_index: 1, elapsed_time: 3, moving_time: 3, distance: 10 },
+      { id: 2, lap_index: 2, elapsed_time: 3, moving_time: 3, distance: 10 },
+    ];
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time"],
+      laps,
+    });
+    const data = result.data as Record<string, unknown[]>;
+    expect(data.lap_index).toEqual([0, 0, 0, 1, 1, 1]);
+    expect(result.metadata.derived_types).toContain("lap_index");
+  });
+});

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -223,6 +223,101 @@ describe("fetchActivityStreams", () => {
     expect((client.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
   });
 
+  // ---------------------------------------------------------------------------
+  // B1-B3 — request-aware filtering, cache shape, availability metadata
+  // ---------------------------------------------------------------------------
+
+  it("cache hit filters output to requested types and reports them in metadata", async () => {
+    // Cache value contains the full payload from a previous call
+    const fullPayload = {
+      rawStreams: {
+        time: { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+        distance: { type: "distance", data: [0, 5, 10], series_type: "time", original_size: 3, resolution: "high" },
+        heartrate: { type: "heartrate", data: [120, 121, 122], series_type: "time", original_size: 3, resolution: "high" },
+        cadence: { type: "cadence", data: [80, 81, 82], series_type: "time", original_size: 3, resolution: "high" },
+      },
+      presentTypes: ["time", "distance", "heartrate", "cadence"],
+    };
+    const kv = makeKv({ "streams:42:all": JSON.stringify(fullPayload) });
+    const client = {
+      fetch: vi.fn(),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 42,
+      streamTypes: ["time", "heartrate"],
+    });
+
+    expect((client.fetch as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    const data = result.data as Record<string, unknown[]>;
+    expect(Object.keys(data).sort()).toEqual(["heartrate", "time"]);
+    expect(result.metadata.requested_types).toEqual(["time", "heartrate"]);
+    expect(result.metadata.returned_types).toEqual(["time", "heartrate"]);
+    expect(result.metadata.unavailable_types).toEqual([]);
+  });
+
+  it("cache miss writes the new {rawStreams, presentTypes} cache shape", async () => {
+    const fixture = makeStreams();
+    const client = makeClient(fixture);
+    const kv = makeKv();
+
+    await fetchActivityStreams(client, kv, { activityId: 99 });
+
+    expect(kv.put).toHaveBeenCalledTimes(1);
+    const cachedRaw = (kv.put as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
+    const parsed = JSON.parse(cachedRaw) as { rawStreams?: unknown; presentTypes?: string[] };
+    expect(parsed.rawStreams).toBeDefined();
+    expect(parsed.presentTypes).toEqual(expect.arrayContaining(["time", "distance", "heartrate"]));
+  });
+
+  it("reads legacy cache entries (no presentTypes field) by deriving from data keys", async () => {
+    // Legacy format: just the rawStreams map directly
+    const legacy = {
+      time: { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+      distance: { type: "distance", data: [0, 5, 10], series_type: "time", original_size: 3, resolution: "high" },
+    };
+    const kv = makeKv({ "streams:7:all": JSON.stringify(legacy) });
+    const client = {
+      fetch: vi.fn(),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 7,
+      streamTypes: ["time", "distance"],
+    });
+
+    expect((client.fetch as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(result.metadata.returned_types).toEqual(["time", "distance"]);
+  });
+
+  it("reports unavailable_types and does NOT re-fetch when a requested type isn't cached", async () => {
+    // Cached payload from a previous call doesn't have watts (Run from a watch
+    // without a power meter). User now asks for watts.
+    const cached = {
+      rawStreams: {
+        time: { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
+        heartrate: { type: "heartrate", data: [120, 121, 122], series_type: "time", original_size: 3, resolution: "high" },
+      },
+      presentTypes: ["time", "heartrate"],
+    };
+    const kv = makeKv({ "streams:55:all": JSON.stringify(cached) });
+    const client = {
+      fetch: vi.fn(),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 55,
+      streamTypes: ["time", "heartrate", "watts"],
+    });
+
+    expect((client.fetch as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(result.metadata.unavailable_types).toContain("watts");
+    expect(result.metadata.returned_types).not.toContain("watts");
+  });
+
   it("preserves nulls in downsampled output", async () => {
     const streams = [
       { type: "time", data: [0, 1, 2, 3, 4], series_type: "time", original_size: 5, resolution: "high" },

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { fetchActivityStreams } from "../src/strava/streams.js";
+import { StravaApiError } from "../src/strava/client.js";
 import type { StravaClient } from "../src/strava/client.js";
 
 function makeKv(initial: Record<string, string> = {}): KVNamespace {
@@ -142,6 +143,84 @@ describe("fetchActivityStreams", () => {
     });
     expect(result.metadata.original_size).toBe(n);
     expect((result.data as Record<string, unknown[]>)["time"]).toHaveLength(n);
+  });
+
+  // ---------------------------------------------------------------------------
+  // A1 — retry on 400 with watts and temp removed (Run with no power meter)
+  // ---------------------------------------------------------------------------
+
+  it("retries without watts and temp when Strava returns 400", async () => {
+    const fixture = makeStreams();
+    const client = {
+      fetch: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new StravaApiError(400, "Strava API error (400): bad watts", false, undefined, {
+            errors: [{ resource: "Stream", field: "watts", code: "invalid" }],
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(fixture), { status: 200 })
+        ),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+    const kv = makeKv();
+
+    const result = await fetchActivityStreams(client, kv, {
+      activityId: 18311335874,
+      streamTypes: ["time", "distance", "heartrate"],
+    });
+
+    expect((client.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+    const firstCallPath = (client.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    const secondCallPath = (client.fetch as ReturnType<typeof vi.fn>).mock.calls[1][0] as string;
+    expect(firstCallPath).toContain("watts");
+    expect(secondCallPath).not.toContain("watts");
+    expect(secondCallPath).not.toContain("temp");
+    expect(result.metadata.returned_types).toContain("time");
+    expect(result.metadata.unavailable_types).not.toContain("time");
+  });
+
+  it("re-throws the 400 with body when the retry without watts also fails", async () => {
+    const errorBody = {
+      message: "Bad Request",
+      errors: [{ resource: "Activity", field: "id", code: "invalid" }],
+    };
+    const client = {
+      fetch: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new StravaApiError(400, "Strava API error (400): first", false, undefined, errorBody)
+        )
+        .mockRejectedValueOnce(
+          new StravaApiError(400, "Strava API error (400): second", false, undefined, errorBody)
+        ),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+    const kv = makeKv();
+
+    const err = await fetchActivityStreams(client, kv, {
+      activityId: 1,
+      streamTypes: ["time"],
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect((err as StravaApiError).status).toBe(400);
+    expect((err as StravaApiError).body).toEqual(errorBody);
+  });
+
+  it("does not catch non-400 errors during the upstream fetch", async () => {
+    const client = {
+      fetch: vi.fn().mockRejectedValue(new StravaApiError(503, "server error", true)),
+      lastRateLimitInfo: null,
+    } as unknown as StravaClient;
+    const kv = makeKv();
+
+    const err = await fetchActivityStreams(client, kv, { activityId: 1 }).catch((e) => e);
+    expect(err).toBeInstanceOf(StravaApiError);
+    expect((err as StravaApiError).status).toBe(503);
+    // No retry should have happened
+    expect((client.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(1);
   });
 
   it("preserves nulls in downsampled output", async () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -165,14 +165,21 @@ describe("get_athlete_profile", () => {
 });
 
 describe("get_recent_activities", () => {
-  it("unfiltered: fetches with per_page=limit and returns the result", async () => {
-    const activities = [{ id: 1 }, { id: 2 }];
+  it("unfiltered: returns {activities, count, next_after, next_before}", async () => {
+    const activities = [
+      { id: 1, start_date: "2025-04-10T08:00:00Z" },
+      { id: 2, start_date: "2025-04-08T08:00:00Z" },
+    ];
     const h = await createHarness([["/athlete/activities", activities]]);
     afterEach(() => h.close());
     const data = parseResult(
       await h.mcpClient.callTool({ name: "get_recent_activities", arguments: { limit: 2 } })
-    ) as unknown[];
-    expect(data).toHaveLength(2);
+    ) as { activities: { id: number }[]; count: number; next_after: number; next_before: number };
+    expect(data.activities).toHaveLength(2);
+    expect(data.count).toBe(2);
+    // Newest activity in the list is the next_after seed for "newer than this"
+    expect(data.next_after).toBe(Math.floor(new Date("2025-04-10T08:00:00Z").getTime() / 1000));
+    expect(data.next_before).toBe(Math.floor(new Date("2025-04-08T08:00:00Z").getTime() / 1000));
     const [path] = h.mockFetch.mock.calls[0] as [string];
     expect(path).toContain("per_page=2");
   });
@@ -184,15 +191,66 @@ describe("get_recent_activities", () => {
     const h = await createHarness([]);
     afterEach(() => h.close());
     h.mockFetch.mockImplementation(async () => {
-      const data = callCount++ === 0 ? runPage : [{ id: 77, type: "Ride", sport_type: "Ride" }];
+      const data =
+        callCount++ === 0
+          ? runPage
+          : [{ id: 77, type: "Ride", sport_type: "Ride", start_date: "2025-04-01T07:00:00Z" }];
       return new Response(JSON.stringify(data), { status: 200 });
     });
     const data = parseResult(
       await h.mcpClient.callTool({ name: "get_recent_activities", arguments: { limit: 1, activity_type: "Ride" } })
-    ) as { id: number }[];
-    expect(data).toHaveLength(1);
-    expect(data[0].id).toBe(77);
+    ) as { activities: { id: number }[] };
+    expect(data.activities).toHaveLength(1);
+    expect(data.activities[0].id).toBe(77);
     expect(h.mockFetch.mock.calls.length).toBe(2);
+  });
+
+  it("fields filter restricts each activity to the whitelist", async () => {
+    const activities = [
+      {
+        id: 1,
+        name: "Morning Run",
+        start_date: "2025-04-10T08:00:00Z",
+        distance: 5000,
+        moving_time: 1500,
+        average_heartrate: 145,
+        kudos_count: 7,
+        comment_count: 0,
+        photo_count: 0,
+      },
+    ];
+    const h = await createHarness([["/athlete/activities", activities]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_recent_activities",
+        arguments: {
+          limit: 1,
+          fields: ["id", "name", "distance", "moving_time", "average_heartrate"],
+        },
+      })
+    ) as { activities: Array<Record<string, unknown>> };
+    expect(Object.keys(data.activities[0]).sort()).toEqual([
+      "average_heartrate",
+      "distance",
+      "id",
+      "moving_time",
+      "name",
+    ]);
+    // Excluded fields really are gone (not just undefined)
+    expect(data.activities[0]).not.toHaveProperty("kudos_count");
+    expect(data.activities[0]).not.toHaveProperty("start_date");
+  });
+
+  it("returns null cursors when no activities matched", async () => {
+    const h = await createHarness([["/athlete/activities", []]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_recent_activities", arguments: { limit: 5 } })
+    ) as { count: number; next_after: number | null; next_before: number | null };
+    expect(data.count).toBe(0);
+    expect(data.next_after).toBeNull();
+    expect(data.next_before).toBeNull();
   });
 });
 
@@ -512,6 +570,152 @@ describe("get_activity_laps", () => {
     expect(data).toHaveLength(2);
     const [path] = h.mockFetch.mock.calls[0] as [string];
     expect(path).toContain("/activities/321/laps");
+  });
+});
+
+describe("get_athlete_summary", () => {
+  it("aggregates monthly buckets with weighted avg HR and pace", async () => {
+    // Three activities: two in Apr 2025, one in May 2025.
+    const activities = [
+      { id: 1, sport_type: "Run", start_date: "2025-04-05T08:00:00Z", start_date_local: "2025-04-05T08:00:00Z", distance: 5000, moving_time: 1500, elapsed_time: 1600, total_elevation_gain: 30, average_heartrate: 150 },
+      { id: 2, sport_type: "Run", start_date: "2025-04-20T08:00:00Z", start_date_local: "2025-04-20T08:00:00Z", distance: 10000, moving_time: 3000, elapsed_time: 3100, total_elevation_gain: 80, average_heartrate: 155 },
+      { id: 3, sport_type: "Run", start_date: "2025-05-02T08:00:00Z", start_date_local: "2025-05-02T08:00:00Z", distance: 3000, moving_time: 900, elapsed_time: 920, total_elevation_gain: 10 },
+    ];
+    const h = await createHarness([["/athlete/activities", activities]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_athlete_summary",
+        arguments: { granularity: "month" },
+      })
+    ) as {
+      buckets: Array<{
+        period_start: string;
+        count: number;
+        total_distance_m: number;
+        avg_heartrate: number | null;
+        avg_pace_per_km: number | null;
+      }>;
+      activity_count: number;
+    };
+    expect(data.activity_count).toBe(3);
+    expect(data.buckets).toHaveLength(2);
+    const apr = data.buckets.find((b) => b.period_start === "2025-04-01")!;
+    expect(apr.count).toBe(2);
+    expect(apr.total_distance_m).toBe(15000);
+    // Weighted avg HR: (150*1500 + 155*3000) / 4500 = 153.33...
+    expect(apr.avg_heartrate).toBeCloseTo((150 * 1500 + 155 * 3000) / 4500, 4);
+    // Avg pace: 4500 / 15 = 300 sec/km
+    expect(apr.avg_pace_per_km).toBeCloseTo(300, 4);
+    const may = data.buckets.find((b) => b.period_start === "2025-05-01")!;
+    expect(may.count).toBe(1);
+    // No HR data on the May activity → null avg
+    expect(may.avg_heartrate).toBeNull();
+  });
+
+  it("filters by activity_type", async () => {
+    const activities = [
+      { id: 1, sport_type: "Run", start_date: "2025-04-05T08:00:00Z", distance: 5000, moving_time: 1500 },
+      { id: 2, sport_type: "Ride", start_date: "2025-04-06T08:00:00Z", distance: 30000, moving_time: 3600 },
+    ];
+    const h = await createHarness([["/athlete/activities", activities]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_athlete_summary",
+        arguments: { activity_type: "Run", granularity: "month" },
+      })
+    ) as { activity_count: number; buckets: Array<{ count: number }> };
+    expect(data.activity_count).toBe(1);
+    expect(data.buckets[0].count).toBe(1);
+  });
+
+  it("supports week granularity (Monday-start ISO weeks)", async () => {
+    // Monday 2025-04-07 → Sunday 2025-04-13 is one ISO week.
+    const activities = [
+      { id: 1, sport_type: "Run", start_date: "2025-04-08T08:00:00Z", distance: 5000, moving_time: 1500 },
+      { id: 2, sport_type: "Run", start_date: "2025-04-13T08:00:00Z", distance: 7000, moving_time: 2000 },
+    ];
+    const h = await createHarness([["/athlete/activities", activities]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_athlete_summary",
+        arguments: { granularity: "week" },
+      })
+    ) as { buckets: Array<{ period_start: string; period_end: string; count: number }> };
+    expect(data.buckets).toHaveLength(1);
+    expect(data.buckets[0].period_start).toBe("2025-04-07");
+    expect(data.buckets[0].period_end).toBe("2025-04-13");
+    expect(data.buckets[0].count).toBe(2);
+  });
+});
+
+describe("get_athlete_best_efforts", () => {
+  it("scans Run activities and returns matching best_efforts sorted fastest-first", async () => {
+    const listPage = [
+      { id: 1, type: "Run", sport_type: "Run", start_date: "2025-04-10T08:00:00Z" },
+      { id: 2, type: "Ride", sport_type: "Ride", start_date: "2025-04-08T08:00:00Z" },
+      { id: 3, type: "Run", sport_type: "Run", start_date: "2025-04-05T08:00:00Z" },
+    ];
+    const h = await createHarness([
+      ["/athlete/activities", listPage],
+      ["/activities/1", {
+        id: 1,
+        name: "Tuesday Tempo",
+        sport_type: "Run",
+        start_date_local: "2025-04-10T08:00:00Z",
+        best_efforts: [
+          { name: "5k", distance: 5000, moving_time: 1240, elapsed_time: 1245, pr_rank: null, is_kom: false, id: 11 },
+        ],
+      }],
+      ["/activities/3", {
+        id: 3,
+        name: "Friday Fast 5",
+        sport_type: "Run",
+        start_date_local: "2025-04-05T08:00:00Z",
+        best_efforts: [
+          { name: "5k", distance: 5000, moving_time: 1180, elapsed_time: 1185, pr_rank: 1, is_kom: false, id: 33 },
+          { name: "10k", distance: 10000, moving_time: 2500 },
+        ],
+      }],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_athlete_best_efforts",
+        arguments: { distance: "5k" },
+      })
+    ) as {
+      results: Array<{ activity_id: number; moving_time: number; pr_rank: number | null }>;
+      activities_scanned: number;
+      activities_with_best_efforts: number;
+    };
+    expect(data.activities_scanned).toBe(2); // Two Runs (the Ride was filtered out)
+    expect(data.activities_with_best_efforts).toBe(2);
+    expect(data.results).toHaveLength(2);
+    // Fastest first
+    expect(data.results[0].moving_time).toBe(1180);
+    expect(data.results[0].pr_rank).toBe(1);
+    expect(data.results[1].moving_time).toBe(1240);
+  });
+
+  it("returns an empty result list when no activities have a matching distance", async () => {
+    const listPage = [
+      { id: 1, type: "Run", sport_type: "Run", start_date: "2025-04-10T08:00:00Z" },
+    ];
+    const h = await createHarness([
+      ["/athlete/activities", listPage],
+      ["/activities/1", { id: 1, sport_type: "Run", best_efforts: [{ name: "10k", distance: 10000, moving_time: 2500 }] }],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({
+        name: "get_athlete_best_efforts",
+        arguments: { distance: "marathon" },
+      })
+    ) as { results: unknown[] };
+    expect(data.results).toEqual([]);
   });
 });
 

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -204,6 +204,48 @@ describe("get_activity_zones", () => {
     const [path] = h.mockFetch.mock.calls[0] as [string];
     expect(path).toContain("/activities/5/zones");
   });
+
+  it("includes seconds_in_zone summed from distribution_buckets", async () => {
+    const zones = [
+      {
+        type: "heartrate",
+        sensor_based: true,
+        points: 10,
+        distribution_buckets: [
+          { min: 0, max: 100, time: 60 },
+          { min: 100, max: 130, time: 300 },
+          { min: 130, max: 150, time: 1200 },
+          { min: 150, max: 170, time: 240 },
+        ],
+      },
+      {
+        type: "power",
+        distribution_buckets: [
+          { min: 0, max: 100, time: 90 },
+          { min: 100, max: 200, time: 600 },
+        ],
+      },
+    ];
+    const h = await createHarness([["/activities/5/zones", zones]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_zones", arguments: { activity_id: 5 } })
+    ) as Array<{ seconds_in_zone: number[] }>;
+    expect(data[0].seconds_in_zone).toEqual([60, 300, 1200, 240]);
+    expect(data[1].seconds_in_zone).toEqual([90, 600]);
+    // Sums match the moving-time-style total per zone block
+    expect(data[0].seconds_in_zone.reduce((a, b) => a + b, 0)).toBe(1800);
+  });
+
+  it("handles zone blocks with missing distribution_buckets gracefully", async () => {
+    const zones = [{ type: "heartrate", sensor_based: false }];
+    const h = await createHarness([["/activities/9/zones", zones]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_zones", arguments: { activity_id: 9 } })
+    ) as Array<{ seconds_in_zone: number[] }>;
+    expect(data[0].seconds_in_zone).toEqual([]);
+  });
 });
 
 describe("get_athlete_zones", () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -515,6 +515,38 @@ describe("get_activity_laps", () => {
   });
 });
 
+describe("get_activity_best_efforts", () => {
+  it("returns Strava's best_efforts list for a Run", async () => {
+    const summary = {
+      id: 1,
+      sport_type: "Run",
+      start_date_local: "2025-04-01T08:00:00Z",
+      best_efforts: [
+        { name: "5k", distance: 5000, moving_time: 1200, pr_rank: 2 },
+        { name: "10k", distance: 10000, moving_time: 2500, pr_rank: null },
+      ],
+    };
+    const h = await createHarness([["/activities/1", summary]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_best_efforts", arguments: { activity_id: 1 } })
+    ) as { sport_type: string; best_efforts: Array<{ name: string }> };
+    expect(data.sport_type).toBe("Run");
+    expect(data.best_efforts).toHaveLength(2);
+    expect(data.best_efforts[0].name).toBe("5k");
+  });
+
+  it("returns an empty list for activities without best_efforts (e.g. Rides)", async () => {
+    const summary = { id: 2, sport_type: "Ride", start_date_local: "2025-04-02T07:00:00Z" };
+    const h = await createHarness([["/activities/2", summary]]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_activity_best_efforts", arguments: { activity_id: 2 } })
+    ) as { best_efforts: unknown[] };
+    expect(data.best_efforts).toEqual([]);
+  });
+});
+
 describe("health (D2)", () => {
   it("returns expected shape on a fresh deploy (no cached athlete, no rate-limit history)", async () => {
     const h = await createHarness([

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -34,7 +34,15 @@ function mockKv(): KVNamespace {
     get: vi.fn().mockImplementation(async (key: string) => store.get(key) ?? null),
     put: vi.fn().mockImplementation(async (key: string, value: string) => { store.set(key, value); }),
     delete: vi.fn().mockImplementation(async (key: string) => { store.delete(key); }),
-    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cacheStatus: null }),
+    list: vi.fn().mockImplementation(async (opts?: { prefix?: string; limit?: number }) => {
+      const prefix = opts?.prefix ?? "";
+      const limit = opts?.limit ?? 1000;
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .slice(0, limit)
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    }),
     getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null, cacheStatus: null }),
   } as unknown as KVNamespace;
 }
@@ -45,10 +53,27 @@ interface Harness {
   close(): Promise<void>;
 }
 
-async function createHarness(routes: FetchRoute[]): Promise<Harness> {
+interface HarnessOptions {
+  tokenCache?: KVNamespace;
+  streamCache?: KVNamespace;
+}
+
+function makeEnv(opts: HarnessOptions = {}): import("../src/types.js").Env {
+  return {
+    TOKEN_CACHE: opts.tokenCache ?? mockKv(),
+    STREAM_CACHE: opts.streamCache ?? mockKv(),
+    IP_RATE_LIMITER: {} as RateLimit,
+    MCP_AUTH_TOKEN: "test-token",
+    STRAVA_CLIENT_ID: "client123",
+    STRAVA_CLIENT_SECRET: "secret456",
+    STRAVA_REFRESH_TOKEN: "refresh789",
+  };
+}
+
+async function createHarness(routes: FetchRoute[], opts: HarnessOptions = {}): Promise<Harness> {
   const stravaClient = mockStravaClient(routes);
   const server = new McpServer({ name: "test", version: "0.0.0" });
-  registerStravaTools(server, stravaClient as unknown as StravaClient, mockKv());
+  registerStravaTools(server, stravaClient as unknown as StravaClient, makeEnv(opts));
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const mcpClient = new Client({ name: "test-client", version: "0.0.0" });
@@ -487,5 +512,71 @@ describe("get_activity_laps", () => {
     expect(data).toHaveLength(2);
     const [path] = h.mockFetch.mock.calls[0] as [string];
     expect(path).toContain("/activities/321/laps");
+  });
+});
+
+describe("health (D2)", () => {
+  it("returns expected shape on a fresh deploy (no cached athlete, no rate-limit history)", async () => {
+    const h = await createHarness([
+      ["/athlete", { id: 42, username: "ada", firstname: "Ada", lastname: "L" }],
+    ]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "health", arguments: {} })
+    ) as {
+      worker_version: string;
+      athlete: { id: number; username: string };
+      rate_limit: unknown;
+      cache: { activity_summaries: number; stream_entries: number; lap_entries: number };
+    };
+    expect(typeof data.worker_version).toBe("string");
+    expect(data.athlete.id).toBe(42);
+    expect(data.athlete.username).toBe("ada");
+    // Fresh deploy: nothing stored yet
+    expect(data.rate_limit).toBeNull();
+    expect(data.cache).toEqual({ activity_summaries: 0, stream_entries: 0, lap_entries: 0 });
+  });
+
+  it("surfaces the latest rate-limit snapshot when one is cached", async () => {
+    const tokenCache = mockKv();
+    await tokenCache.put(
+      "rate_limit:latest",
+      JSON.stringify({
+        shortTermLimit: 100,
+        shortTermUsage: 7,
+        dailyLimit: 1000,
+        dailyUsage: 88,
+        updated_at: 1700000000,
+      })
+    );
+    const h = await createHarness(
+      [["/athlete", { id: 1, username: "u" }]],
+      { tokenCache }
+    );
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "health", arguments: {} })
+    ) as { rate_limit: { shortTermUsage: number; dailyUsage: number } };
+    expect(data.rate_limit.shortTermUsage).toBe(7);
+    expect(data.rate_limit.dailyUsage).toBe(88);
+  });
+
+  it("counts cache entries by prefix", async () => {
+    const streamCache = mockKv();
+    await streamCache.put("streams:1:all", "{}");
+    await streamCache.put("streams:2:all", "{}");
+    await streamCache.put("activity:1:summary", "{}");
+    await streamCache.put("laps:1", "[]");
+    await streamCache.put("laps:2", "[]");
+    await streamCache.put("laps:3", "[]");
+    const h = await createHarness(
+      [["/athlete", { id: 1, username: "u" }]],
+      { streamCache }
+    );
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "health", arguments: {} })
+    ) as { cache: { activity_summaries: number; stream_entries: number; lap_entries: number } };
+    expect(data.cache).toEqual({ activity_summaries: 1, stream_entries: 2, lap_entries: 3 });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the universal `get_activity_streams` 400 (root cause: `resolution=all` was hardcoded but Strava only accepts `low | medium | high`), surfaces upstream Strava error bodies, and adds a set of sport-aware and trend-analysis improvements driven by both the original task brief and follow-up usage feedback.

### Critical fix
- **Streams 400** — Strava rejects `resolution=all`. Switched to `resolution=high` (same fidelity), removed `"all"` from the user-facing enum. Verified live against activity 18311335874.
- **Upstream error bodies** are now surfaced on every non-OK Strava response, with the parsed body attached as `body` on the thrown `StravaApiError`. This is what made the resolution bug diagnosable.

### Tool design
- **Sport-aware default streams** — Runs/Walks/Hikes don't request `watts`; Rides do. Falls back gracefully to a generic default when sport_type is unknown.
- **`units` mode** — `auto` (default) adds `pace_per_km` for runs and `speed_kmh` for rides alongside `velocity_smooth`. Pause samples come back as `null`, not `Infinity`.
- **Optional `lap_index`** column aligned with the time stream (computed from cumulative `elapsed_time`, so it survives downsampling).
- **`seconds_in_zone`** added to `get_activity_zones` per zone block.
- **Stream windowing** — `time_range_seconds` and `distance_range_meters` parameters slice the cached payload server-side. 27% payload on a verified 1-km window.
- **`get_activity_best_efforts`** — projects Strava's pre-computed `best_efforts` off the activity summary.
- **`get_athlete_best_efforts`** — Strava-computed best efforts at one distance across many Runs, sorted fastest-first.
- **`get_athlete_summary`** — weekly or monthly rollups (count, distance, moving time, elevation, weighted avg HR, avg pace) — pure arithmetic over Strava activity-summary fields, no opinions.
- **`get_recent_activities`** — new envelope shape `{activities, count, next_after, next_before}` (cursors avoid off-by-one paging mistakes), optional `fields` whitelist (~70-80% payload reduction).

### Operational
- **Structured logging** to `console.log` as single-line JSON; `LOG_LEVEL` env var (default `info`); auth tokens and client secrets are redacted before serialisation.
- **Rate-limit persistence** — every Strava response writes the latest headers to `rate_limit:latest` in TOKEN_CACHE. 429 maps to `RATE_LIMITED` (was `STRAVA_RATE_LIMIT`).
- **`health` tool** — athlete identity, last-seen rate limit, cache stats, worker version.

### Notable deliberate non-goals
- **`analyse_activity` / `compare_activities`** were in the original brief but skipped — they bake in interpretive defaults (HR drift slope, pace variability threshold, split granularity) which CLAUDE.md explicitly forbids. The aggregations included here (summary, best efforts) are arithmetic over Strava-supplied fields, not analytical opinions.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test:run` (121 tests, all green)
- [x] Live verification via `wrangler dev`:
  - [x] `health` returns athlete + rate-limit + cache stats
  - [x] activity 18311335874 (the previously-broken Run) returns 1931 samples
  - [x] Ride without a power meter: retry path strips watts/temp; `unavailable_types` reports it
  - [x] `distance_range_meters` slices to ~27% of the original payload, bounds reported in metadata
  - [x] `get_athlete_summary` produces 6 monthly buckets from 68 activities in one Strava call
  - [x] `get_athlete_best_efforts(distance="5k")` returns fastest-first list
- [ ] After deploy: run the same five tool calls against `https://strava-mcp.mikekeefe.workers.dev/mcp`
- [ ] Reconnect the Claude connector (mobile + desktop) so the new tool list is picked up

## Breaking changes
- `STRAVA_RATE_LIMIT` MCP error code → `RATE_LIMITED`.
- `get_recent_activities` now returns an object envelope, not a bare array.
- `resolution` param on `get_activity_streams` no longer accepts `"all"` (Strava rejected it anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)