### PR TITLE
[#compliance] Strava compliance: revocation, deauth webhook, GitHub Pages, read rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ The Worker URL is printed at the end: `https://strava-mcp.<your-subdomain>.worke
 ```bash
 npx wrangler secret put STRAVA_CLIENT_ID
 npx wrangler secret put STRAVA_CLIENT_SECRET
-npx wrangler secret put MCP_AUTH_TOKEN   # any random string — used for direct API access
+npx wrangler secret put MCP_AUTH_TOKEN        # any random string — used for direct API access
+npx wrangler secret put WEBHOOK_VERIFY_TOKEN  # any random string — used to verify Strava webhooks
 ```
 
 > **Note:** `STRAVA_REFRESH_TOKEN` is only needed if you want to use the static `MCP_AUTH_TOKEN` admin path. Users connecting through Claude's OAuth flow don't need it.
@@ -206,9 +207,24 @@ Tests use [Vitest](https://vitest.dev/) with `@cloudflare/vitest-pool-workers`. 
 | `STRAVA_CLIENT_ID` | Yes | Strava app Client ID |
 | `STRAVA_CLIENT_SECRET` | Yes | Strava app Client Secret |
 | `MCP_AUTH_TOKEN` | Yes | Bearer token for direct API access |
+| `WEBHOOK_VERIFY_TOKEN` | Yes | Random string used to verify the Strava push subscription |
 | `STRAVA_REFRESH_TOKEN` | Optional | Long-lived refresh token for the static auth path |
 
 Set via `npx wrangler secret put <NAME>`. Never commit these.
+
+### Registering the Strava webhook subscription (one-time)
+
+After deploying, register the push subscription so Strava can notify this server when a user deauthorizes the app:
+
+```bash
+curl -X POST https://www.strava.com/api/v3/push_subscriptions \
+  -F client_id=<STRAVA_CLIENT_ID> \
+  -F client_secret=<STRAVA_CLIENT_SECRET> \
+  -F callback_url=https://strava-mcp.<your-subdomain>.workers.dev/webhook \
+  -F verify_token=<WEBHOOK_VERIFY_TOKEN>
+```
+
+Strava immediately sends a `GET /webhook?hub.mode=subscribe&hub.challenge=...` to verify the endpoint. The Worker responds automatically. On success, Strava returns a subscription ID — no further action needed.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>strava-mcp — Strava for Claude</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f0f0f;
+      color: #e8e8e8;
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      border-bottom: 1px solid #222;
+      padding: 1.5rem 2rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+
+    header h1 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+    }
+
+    header .badge {
+      background: #fc4c02;
+      color: #fff;
+      font-size: 0.65rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      padding: 0.2rem 0.55rem;
+      border-radius: 3px;
+    }
+
+    main {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 4rem 2rem;
+      flex: 1;
+    }
+
+    .hero h2 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      letter-spacing: -0.04em;
+      line-height: 1.15;
+      margin-bottom: 1.25rem;
+    }
+
+    .hero p {
+      font-size: 1.1rem;
+      color: #aaa;
+      max-width: 540px;
+      margin-bottom: 2rem;
+    }
+
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      background: #fc4c02;
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      transition: background 0.15s;
+    }
+
+    .cta:hover { background: #e04402; }
+
+    .cta-secondary {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: 1px solid #333;
+      color: #ccc;
+      font-weight: 500;
+      font-size: 0.95rem;
+      padding: 0.75rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      margin-left: 0.75rem;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .cta-secondary:hover { border-color: #666; color: #fff; }
+
+    .diagram {
+      background: #161616;
+      border: 1px solid #222;
+      border-radius: 8px;
+      padding: 1.5rem 2rem;
+      margin: 3rem 0;
+      font-family: "SF Mono", "Fira Code", monospace;
+      font-size: 0.85rem;
+      color: #888;
+      text-align: center;
+    }
+
+    .diagram .arrow { color: #fc4c02; }
+
+    section { margin: 3.5rem 0; }
+
+    section h3 {
+      font-size: 1.15rem;
+      font-weight: 600;
+      margin-bottom: 1.25rem;
+      color: #fff;
+    }
+
+    .tools-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 0.75rem;
+    }
+
+    .tool {
+      background: #161616;
+      border: 1px solid #222;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+    }
+
+    .tool code {
+      font-family: "SF Mono", "Fira Code", monospace;
+      font-size: 0.78rem;
+      color: #fc4c02;
+      display: block;
+      margin-bottom: 0.3rem;
+    }
+
+    .tool p {
+      font-size: 0.82rem;
+      color: #888;
+    }
+
+    .steps ol {
+      list-style: none;
+      counter-reset: steps;
+    }
+
+    .steps ol li {
+      counter-increment: steps;
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.25rem;
+      align-items: flex-start;
+    }
+
+    .steps ol li::before {
+      content: counter(steps);
+      background: #222;
+      border: 1px solid #333;
+      color: #aaa;
+      font-size: 0.75rem;
+      font-weight: 700;
+      width: 1.75rem;
+      height: 1.75rem;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      margin-top: 0.1rem;
+    }
+
+    .steps li p { color: #aaa; font-size: 0.95rem; }
+    .steps li strong { color: #e8e8e8; }
+
+    .privacy-note {
+      background: #161616;
+      border: 1px solid #222;
+      border-left: 3px solid #fc4c02;
+      border-radius: 6px;
+      padding: 1rem 1.25rem;
+      font-size: 0.88rem;
+      color: #999;
+    }
+
+    .privacy-note a { color: #fc4c02; text-decoration: none; }
+    .privacy-note a:hover { text-decoration: underline; }
+
+    footer {
+      border-top: 1px solid #1a1a1a;
+      padding: 2rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #555;
+    }
+
+    footer a { color: #888; text-decoration: none; }
+    footer a:hover { color: #ccc; }
+
+    .strava-attribution {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .strava-attribution img { height: 20px; opacity: 0.6; }
+
+    @media (max-width: 600px) {
+      .hero h2 { font-size: 1.75rem; }
+      .cta-secondary { margin-left: 0; margin-top: 0.75rem; }
+      .cta, .cta-secondary { display: flex; width: 100%; justify-content: center; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>strava-mcp</h1>
+  <span class="badge">Open Source</span>
+</header>
+
+<main>
+  <div class="hero">
+    <h2>Your Strava data,<br>inside Claude.</h2>
+    <p>A remote MCP server that connects Claude to your Strava account. Ask Claude to analyse training trends, explore segments, compare efforts, and more — all in conversation.</p>
+    <a class="cta" href="https://github.com/mike-keefe/strava-mcp">View on GitHub</a>
+    <a class="cta-secondary" href="privacy.html">Privacy policy</a>
+  </div>
+
+  <div class="diagram">
+    Claude <span class="arrow">──OAuth 2.0──▶</span> strava-mcp Worker <span class="arrow">──Strava API──▶</span> Your activity data
+  </div>
+
+  <section>
+    <h3>15 read-only tools</h3>
+    <div class="tools-grid">
+      <div class="tool"><code>get_athlete_profile</code><p>Name, location, weight, FTP</p></div>
+      <div class="tool"><code>get_recent_activities</code><p>Activity list with filters</p></div>
+      <div class="tool"><code>get_activity_details</code><p>Full activity breakdown</p></div>
+      <div class="tool"><code>get_activity_streams</code><p>Raw per-second data</p></div>
+      <div class="tool"><code>get_activity_zones</code><p>HR &amp; power zone distribution</p></div>
+      <div class="tool"><code>get_activity_laps</code><p>Manually-pressed laps</p></div>
+      <div class="tool"><code>get_athlete_zones</code><p>Your zone thresholds</p></div>
+      <div class="tool"><code>get_athlete_stats</code><p>Recent / YTD / all-time totals</p></div>
+      <div class="tool"><code>get_segment_details</code><p>Segment info &amp; your PR</p></div>
+      <div class="tool"><code>list_my_segment_efforts</code><p>All efforts on a segment</p></div>
+      <div class="tool"><code>get_segment_effort_streams</code><p>Per-second segment streams</p></div>
+      <div class="tool"><code>explore_segments</code><p>Find segments in a bounding box</p></div>
+      <div class="tool"><code>list_routes</code><p>Your saved routes</p></div>
+      <div class="tool"><code>get_route_details</code><p>Route metadata &amp; streams</p></div>
+      <div class="tool"><code>list_gear</code><p>Bikes &amp; shoes with mileage</p></div>
+    </div>
+  </section>
+
+  <section>
+    <h3>Deploy your own in 7 steps</h3>
+    <div class="steps">
+      <ol>
+        <li><p><strong>Clone the repo</strong> and run <code>pnpm install</code>.</p></li>
+        <li><p><strong>Create a Strava API app</strong> at <a href="https://www.strava.com/settings/api" style="color:#fc4c02">strava.com/settings/api</a>. Note your Client ID and Secret.</p></li>
+        <li><p><strong>Create a Cloudflare account</strong> (free tier works) and run <code>npx wrangler login</code>.</p></li>
+        <li><p><strong>Create KV namespaces</strong> with <code>npx wrangler kv namespace create TOKEN_CACHE</code> and <code>STREAM_CACHE</code>. Paste the IDs into <code>wrangler.jsonc</code>.</p></li>
+        <li><p><strong>Deploy</strong> with <code>pnpm run deploy</code>. Your Worker URL is printed at the end.</p></li>
+        <li><p><strong>Set secrets</strong> — <code>STRAVA_CLIENT_ID</code>, <code>STRAVA_CLIENT_SECRET</code>, <code>MCP_AUTH_TOKEN</code> — via <code>npx wrangler secret put</code>.</p></li>
+        <li><p><strong>Add the connector in Claude</strong>: Settings → Connectors → Add custom connector → paste your Worker URL + <code>/mcp</code>.</p></li>
+      </ol>
+    </div>
+  </section>
+
+  <section>
+    <div class="privacy-note">
+      <strong>Privacy:</strong> This server is a thin pass-through. It stores only the OAuth tokens needed to call the Strava API on your behalf. No activity data is stored permanently. You can revoke access at any time from Strava's connected apps page or by disconnecting the connector in Claude. <a href="privacy.html">Full privacy policy →</a>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="strava-attribution">
+    <svg height="20" viewBox="0 0 100 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Powered by Strava">
+      <text x="0" y="15" fill="#fc4c02" font-family="-apple-system, sans-serif" font-size="11" font-weight="700" letter-spacing="0.5">Powered by Strava</text>
+    </svg>
+  </div>
+  <p>
+    <a href="https://github.com/mike-keefe/strava-mcp">GitHub</a> &middot;
+    <a href="privacy.html">Privacy</a> &middot;
+    <a href="https://developers.strava.com">Strava API</a>
+  </p>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,11 +207,20 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 0.5rem;
+      gap: 0.4rem;
       margin-bottom: 0.75rem;
+      font-size: 0.8rem;
+      color: #666;
     }
 
-    .strava-attribution img { height: 20px; opacity: 0.6; }
+    .strava-attribution a {
+      color: #fc4c02;
+      font-weight: 700;
+      text-decoration: none;
+      letter-spacing: -0.01em;
+    }
+
+    .strava-attribution a:hover { text-decoration: underline; }
 
     @media (max-width: 600px) {
       .hero h2 { font-size: 1.75rem; }
@@ -284,9 +293,7 @@
 
 <footer>
   <div class="strava-attribution">
-    <svg height="20" viewBox="0 0 100 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-label="Powered by Strava">
-      <text x="0" y="15" fill="#fc4c02" font-family="-apple-system, sans-serif" font-size="11" font-weight="700" letter-spacing="0.5">Powered by Strava</text>
-    </svg>
+    Powered by <a href="https://www.strava.com" rel="noopener">Strava</a>
   </div>
   <p>
     <a href="https://github.com/mike-keefe/strava-mcp">GitHub</a> &middot;

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -140,10 +140,10 @@
   <h2>Your rights (GDPR / right to erasure)</h2>
   <p>You have the right to delete all data associated with your account at any time. To do so:</p>
   <ul>
-    <li><strong>Disconnect the connector in Claude</strong> — this revokes your token and triggers deletion of all associated KV records, including any cached stream data.</li>
-    <li><strong>Revoke access on Strava</strong> — go to <a href="https://www.strava.com/settings/apps">strava.com/settings/apps</a> and remove this app. This invalidates the underlying Strava tokens.</li>
+    <li><strong>Disconnect the connector in Claude</strong> — this revokes your token and triggers immediate deletion of all associated KV records, including any cached stream data.</li>
+    <li><strong>Revoke access on Strava</strong> — go to <a href="https://www.strava.com/settings/apps">strava.com/settings/apps</a> and remove this app. Strava notifies this server via webhook and all your stored data (tokens, stream cache) is deleted within seconds.</li>
   </ul>
-  <p>Both actions are sufficient to ensure your data is removed from this server.</p>
+  <p>Either action is sufficient to ensure your data is removed from this server.</p>
 
   <h2>Strava API terms</h2>
   <p>This application uses the <a href="https://developers.strava.com">Strava API</a> and complies with the <a href="https://www.strava.com/legal/api">Strava API Agreement</a>. By using this server, you also agree to Strava's terms. This application uses only read-only scopes (<code>read</code>, <code>activity:read_all</code>, <code>profile:read_all</code>) and never modifies your Strava data.</p>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — strava-mcp</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0f0f0f;
+      color: #e8e8e8;
+      line-height: 1.7;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      border-bottom: 1px solid #222;
+      padding: 1.5rem 2rem;
+    }
+
+    header a {
+      color: #888;
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+
+    header a:hover { color: #fff; }
+
+    main {
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 4rem 2rem;
+      flex: 1;
+    }
+
+    h1 {
+      font-size: 2rem;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      margin-bottom: 0.5rem;
+    }
+
+    .updated {
+      color: #666;
+      font-size: 0.85rem;
+      margin-bottom: 3rem;
+    }
+
+    h2 {
+      font-size: 1.05rem;
+      font-weight: 600;
+      margin: 2.5rem 0 0.75rem;
+      color: #fff;
+    }
+
+    p, li {
+      color: #aaa;
+      font-size: 0.95rem;
+      margin-bottom: 0.75rem;
+    }
+
+    ul {
+      padding-left: 1.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    ul li { margin-bottom: 0.4rem; }
+
+    a { color: #fc4c02; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .highlight {
+      background: #161616;
+      border: 1px solid #222;
+      border-left: 3px solid #fc4c02;
+      border-radius: 6px;
+      padding: 1rem 1.25rem;
+      margin: 1.5rem 0;
+    }
+
+    .highlight p { margin-bottom: 0; }
+
+    footer {
+      border-top: 1px solid #1a1a1a;
+      padding: 1.5rem 2rem;
+      text-align: center;
+      font-size: 0.8rem;
+      color: #555;
+    }
+
+    footer a { color: #888; text-decoration: none; }
+    footer a:hover { color: #ccc; }
+  </style>
+</head>
+<body>
+
+<header>
+  <a href="index.html">← strava-mcp</a>
+</header>
+
+<main>
+  <h1>Privacy Policy</h1>
+  <p class="updated">Last updated: April 2025</p>
+
+  <div class="highlight">
+    <p>Short version: this server stores only the tokens needed to call the Strava API on your behalf. No activity data, routes, or health metrics are stored permanently. You can delete your data at any time.</p>
+  </div>
+
+  <h2>What data is stored</h2>
+  <p>When you connect your Strava account, the following is stored in Cloudflare KV (a key-value store operated by Cloudflare, Inc.):</p>
+  <ul>
+    <li>An OAuth access token issued by this server (used to authenticate your requests to the MCP server)</li>
+    <li>Your Strava refresh token (used to request fresh Strava access tokens on your behalf)</li>
+    <li>A cached Strava access token (short-lived, refreshed automatically)</li>
+    <li>Temporarily: stream data from individual Strava activities, cached for up to 30 days to reduce API calls to Strava. This cache is stored per-user and deleted when you revoke access.</li>
+  </ul>
+
+  <h2>What data is never stored</h2>
+  <ul>
+    <li>Your name, email, or Strava profile details</li>
+    <li>Your activity history, routes, segments, or any other Strava data beyond the short-lived stream cache described above</li>
+    <li>Any data beyond what is needed to fulfil your requests to Claude</li>
+  </ul>
+
+  <h2>How data is used</h2>
+  <p>Tokens are used solely to call the Strava API in response to your requests made through Claude. No data is shared with third parties, used for analytics, or sold.</p>
+  <p>This server is a thin pass-through. It does not analyse, process, or store your Strava activity data. All data returned from the Strava API is passed directly to Claude and is not retained.</p>
+
+  <h2>Data retention</h2>
+  <ul>
+    <li>OAuth access tokens: stored for up to 1 year, or until revoked.</li>
+    <li>Strava access token cache: expires automatically (typically 6 hours).</li>
+    <li>Stream cache: expires after 30 days per activity, or is deleted immediately on revocation.</li>
+  </ul>
+
+  <h2>Your rights (GDPR / right to erasure)</h2>
+  <p>You have the right to delete all data associated with your account at any time. To do so:</p>
+  <ul>
+    <li><strong>Disconnect the connector in Claude</strong> — this revokes your token and triggers deletion of all associated KV records, including any cached stream data.</li>
+    <li><strong>Revoke access on Strava</strong> — go to <a href="https://www.strava.com/settings/apps">strava.com/settings/apps</a> and remove this app. This invalidates the underlying Strava tokens.</li>
+  </ul>
+  <p>Both actions are sufficient to ensure your data is removed from this server.</p>
+
+  <h2>Strava API terms</h2>
+  <p>This application uses the <a href="https://developers.strava.com">Strava API</a> and complies with the <a href="https://www.strava.com/legal/api">Strava API Agreement</a>. By using this server, you also agree to Strava's terms. This application uses only read-only scopes (<code>read</code>, <code>activity:read_all</code>, <code>profile:read_all</code>) and never modifies your Strava data.</p>
+
+  <h2>Self-hosted deployments</h2>
+  <p>strava-mcp is open source. If you deploy your own instance, you control all stored data. This privacy policy applies only to instances explicitly operated by the project maintainer. For self-hosted deployments, you are the data controller.</p>
+
+  <h2>Infrastructure</h2>
+  <p>This server runs on <a href="https://workers.cloudflare.com">Cloudflare Workers</a>. Token data is stored in <a href="https://developers.cloudflare.com/kv/">Cloudflare KV</a>, which is subject to <a href="https://www.cloudflare.com/privacypolicy/">Cloudflare's privacy policy</a>. Cloudflare may process data in multiple regions.</p>
+
+  <h2>Observability and logging</h2>
+  <p>Worker-level observability is disabled. No request logs, token values, or response bodies are stored by the server. Standard Cloudflare infrastructure logs (IP addresses, request counts) may be retained by Cloudflare per their own policy.</p>
+
+  <h2>Contact</h2>
+  <p>For privacy-related requests or questions, open an issue at <a href="https://github.com/mike-keefe/strava-mcp">github.com/mike-keefe/strava-mcp</a> or email <a href="mailto:mikekeefe91@gmail.com">mikekeefe91@gmail.com</a>.</p>
+</main>
+
+<footer>
+  <p><a href="index.html">strava-mcp</a> &middot; <a href="https://github.com/mike-keefe/strava-mcp">GitHub</a></p>
+</footer>
+
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ function rateLimitedResponse(): Response {
 function buildMcpServer(env: Env, userOAuthToken?: string): McpServer {
   const server = new McpServer({ name: "strava-mcp", version: "0.1.0" });
   const client = new StravaClient(env, userOAuthToken);
-  registerStravaTools(server, client, env);
+  registerStravaTools(server, client, env, userOAuthToken);
   return server;
 }
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -56,6 +56,9 @@ export async function handleOAuth(request: Request, env: Env): Promise<Response>
   if (pathname === "/oauth/token" && request.method === "POST") {
     return tokenEndpoint(request, env, origin);
   }
+  if (pathname === "/oauth/revoke" && request.method === "POST") {
+    return revokeEndpoint(request, env);
+  }
   return new Response("Not Found", { status: 404 });
 }
 
@@ -78,11 +81,13 @@ function authServerMetadata(origin: string): Response {
     authorization_endpoint: `${origin}/oauth/authorize`,
     token_endpoint: `${origin}/oauth/token`,
     registration_endpoint: `${origin}/oauth/register`,
+    revocation_endpoint: `${origin}/oauth/revoke`,
     scopes_supported: ["mcp"],
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
+    revocation_endpoint_auth_methods_supported: ["none"],
   });
 }
 
@@ -398,6 +403,45 @@ async function handleAuthCodeGrant(
     expires_in: TOKEN_TTL_SECONDS,
     scope: "mcp",
   });
+}
+
+// ---------------------------------------------------------------------------
+// Revocation endpoint (RFC 7009)
+// ---------------------------------------------------------------------------
+
+async function revokeEndpoint(request: Request, env: Env): Promise<Response> {
+  let body: URLSearchParams;
+  try {
+    body = new URLSearchParams(await request.text());
+  } catch {
+    return oauthError("invalid_request", "Invalid request body");
+  }
+
+  const token = body.get("token");
+  if (!token) {
+    return oauthError("invalid_request", "token parameter is required");
+  }
+
+  // RFC 7009 §2.2: unknown/already-revoked tokens MUST return 200
+  const exists = await env.TOKEN_CACHE.get(KV.token(token));
+  if (!exists) {
+    return new Response(null, { status: 200 });
+  }
+
+  // Delete our token record and the cached Strava access token in parallel
+  await Promise.all([
+    env.TOKEN_CACHE.delete(KV.token(token)),
+    env.TOKEN_CACHE.delete(stravaTokenCacheKey(token)),
+  ]);
+
+  // Delete any stream cache entries for this user
+  const streamPrefix = `${token}:streams:`;
+  const listed = await env.STREAM_CACHE.list({ prefix: streamPrefix });
+  if (listed.keys.length > 0) {
+    await Promise.all(listed.keys.map((k) => env.STREAM_CACHE.delete(k.name)));
+  }
+
+  return new Response(null, { status: 200 });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -8,6 +8,8 @@ const KV = {
   token: (t: string) => `oauth:token:${t}`,
   client: (id: string) => `oauth:client:${id}`,
   session: (s: string) => `oauth:session:${s}`,
+  // Reverse index: Strava athlete ID → our OAuth token (for webhook deauth)
+  athlete: (id: number) => `strava:athlete:${id}`,
 };
 
 const SESSION_TTL_SECONDS = 600; // 10 min to complete Strava auth
@@ -16,6 +18,7 @@ const TOKEN_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 
 const STRAVA_AUTH_URL = "https://www.strava.com/oauth/authorize";
 const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
+const STRAVA_API_BASE = "https://www.strava.com/api/v3";
 const STRAVA_SCOPES = "read,activity:read_all,profile:read_all";
 
 // Shared with StravaClient — per-user Strava access token cache key
@@ -30,6 +33,7 @@ export function isOAuthPath(pathname: string): boolean {
   return (
     pathname === "/.well-known/oauth-authorization-server" ||
     pathname === "/.well-known/oauth-protected-resource" ||
+    pathname === "/webhook" ||
     pathname.startsWith("/oauth/")
   );
 }
@@ -58,6 +62,12 @@ export async function handleOAuth(request: Request, env: Env): Promise<Response>
   }
   if (pathname === "/oauth/revoke" && request.method === "POST") {
     return revokeEndpoint(request, env);
+  }
+  if (pathname === "/webhook" && request.method === "GET") {
+    return webhookVerify(request, env);
+  }
+  if (pathname === "/webhook" && request.method === "POST") {
+    return webhookEvent(request, env);
   }
   return new Response("Not Found", { status: 404 });
 }
@@ -397,12 +407,43 @@ async function handleAuthCodeGrant(
     );
   }
 
+  // Store a reverse index (Strava athlete ID → our OAuth token) so the
+  // deauthorization webhook can look up and clean up the right user's data.
+  try {
+    const athleteRes = await fetch(`${STRAVA_API_BASE}/athlete`, {
+      headers: { Authorization: `Bearer ${codeRecord.stravaAccessToken}` },
+    });
+    if (athleteRes.ok) {
+      const athlete = (await athleteRes.json()) as { id: number };
+      await env.TOKEN_CACHE.put(KV.athlete(athlete.id), accessToken, {
+        expirationTtl: TOKEN_TTL_SECONDS,
+      });
+    }
+  } catch {
+    // Non-fatal: webhook deauth lookup won't work but /oauth/revoke still will
+  }
+
   return json({
     access_token: accessToken,
     token_type: "Bearer",
     expires_in: TOKEN_TTL_SECONDS,
     scope: "mcp",
   });
+}
+
+// ---------------------------------------------------------------------------
+// Shared user data cleanup — used by /oauth/revoke and the webhook
+// ---------------------------------------------------------------------------
+
+async function deleteUserData(oauthToken: string, env: Env): Promise<void> {
+  await Promise.all([
+    env.TOKEN_CACHE.delete(KV.token(oauthToken)),
+    env.TOKEN_CACHE.delete(stravaTokenCacheKey(oauthToken)),
+  ]);
+  const listed = await env.STREAM_CACHE.list({ prefix: `${oauthToken}:streams:` });
+  if (listed.keys.length > 0) {
+    await Promise.all(listed.keys.map((k) => env.STREAM_CACHE.delete(k.name)));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -428,17 +469,50 @@ async function revokeEndpoint(request: Request, env: Env): Promise<Response> {
     return new Response(null, { status: 200 });
   }
 
-  // Delete our token record and the cached Strava access token in parallel
-  await Promise.all([
-    env.TOKEN_CACHE.delete(KV.token(token)),
-    env.TOKEN_CACHE.delete(stravaTokenCacheKey(token)),
-  ]);
+  await deleteUserData(token, env);
+  return new Response(null, { status: 200 });
+}
 
-  // Delete any stream cache entries for this user
-  const streamPrefix = `${token}:streams:`;
-  const listed = await env.STREAM_CACHE.list({ prefix: streamPrefix });
-  if (listed.keys.length > 0) {
-    await Promise.all(listed.keys.map((k) => env.STREAM_CACHE.delete(k.name)));
+// ---------------------------------------------------------------------------
+// Strava webhook (push subscription) — deauthorization events
+// ---------------------------------------------------------------------------
+
+function webhookVerify(request: Request, env: Env): Response {
+  const url = new URL(request.url);
+  const mode = url.searchParams.get("hub.mode");
+  const challenge = url.searchParams.get("hub.challenge");
+  const verifyToken = url.searchParams.get("hub.verify_token");
+
+  if (mode !== "subscribe" || !challenge) {
+    return new Response("Bad Request", { status: 400 });
+  }
+  if (!env.WEBHOOK_VERIFY_TOKEN || verifyToken !== env.WEBHOOK_VERIFY_TOKEN) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  return json({ "hub.challenge": challenge });
+}
+
+async function webhookEvent(request: Request, env: Env): Promise<Response> {
+  let event: { object_type?: string; aspect_type?: string; owner_id?: number };
+  try {
+    event = (await request.json()) as typeof event;
+  } catch {
+    return new Response("Bad Request", { status: 400 });
+  }
+
+  // Only act on athlete deauthorization; acknowledge all other events
+  if (event.object_type !== "athlete" || event.aspect_type !== "delete") {
+    return new Response(null, { status: 200 });
+  }
+
+  const athleteId = event.owner_id;
+  if (typeof athleteId === "number") {
+    const oauthToken = await env.TOKEN_CACHE.get(KV.athlete(athleteId));
+    if (oauthToken) {
+      await deleteUserData(oauthToken, env);
+      await env.TOKEN_CACHE.delete(KV.athlete(athleteId));
+    }
   }
 
   return new Response(null, { status: 200 });

--- a/src/strava/client.ts
+++ b/src/strava/client.ts
@@ -244,8 +244,13 @@ export class StravaClient {
         const retryAfterSeconds = resetHeader
           ? Math.max(1, parseInt(resetHeader, 10) - Math.floor(Date.now() / 1000))
           : 60;
-        const limitInfo = this.lastRateLimitInfo
-          ? `(usage: ${this.lastRateLimitInfo.shortTermUsage}/${this.lastRateLimitInfo.shortTermLimit} short-term, ${this.lastRateLimitInfo.dailyUsage}/${this.lastRateLimitInfo.dailyLimit} daily)`
+        const li = this.lastRateLimitInfo;
+        const limitInfo = li
+          ? `(overall: ${li.shortTermUsage}/${li.shortTermLimit} short-term, ${li.dailyUsage}/${li.dailyLimit} daily` +
+            (li.readShortTermLimit !== undefined
+              ? `; read: ${li.readShortTermUsage}/${li.readShortTermLimit} short-term, ${li.readDailyUsage}/${li.readDailyLimit} daily`
+              : "") +
+            ")"
           : "";
         throw new StravaApiError(
           429,
@@ -314,5 +319,21 @@ function parseRateLimitHeaders(headers: Headers): StravaRateLimitInfo | null {
   const [shortTermLimit, dailyLimit] = limit.split(",").map(Number);
   const [shortTermUsage, dailyUsage] = usage.split(",").map(Number);
   if ([shortTermLimit, dailyLimit, shortTermUsage, dailyUsage].some(isNaN)) return null;
-  return { shortTermLimit, shortTermUsage, dailyLimit, dailyUsage };
+
+  const info: StravaRateLimitInfo = { shortTermLimit, shortTermUsage, dailyLimit, dailyUsage };
+
+  const readLimit = headers.get("X-ReadRateLimit-Limit");
+  const readUsage = headers.get("X-ReadRateLimit-Usage");
+  if (readLimit && readUsage) {
+    const [readShortTermLimit, readDailyLimit] = readLimit.split(",").map(Number);
+    const [readShortTermUsage, readDailyUsage] = readUsage.split(",").map(Number);
+    if (![readShortTermLimit, readDailyLimit, readShortTermUsage, readDailyUsage].some(isNaN)) {
+      info.readShortTermLimit = readShortTermLimit;
+      info.readShortTermUsage = readShortTermUsage;
+      info.readDailyLimit = readDailyLimit;
+      info.readDailyUsage = readDailyUsage;
+    }
+  }
+
+  return info;
 }

--- a/src/strava/streams.ts
+++ b/src/strava/streams.ts
@@ -19,6 +19,7 @@ export interface StreamsParams {
   timeRangeSeconds?: { start?: number; end?: number };
   // Inclusive distance range in metres along the distance stream.
   distanceRangeMeters?: { start?: number; end?: number };
+  userPrefix?: string;
 }
 
 // Anything below this in m/s (~ 22:13 / km) is treated as stopped for the
@@ -152,6 +153,7 @@ export async function fetchActivityStreams(
     laps,
     timeRangeSeconds,
     distanceRangeMeters,
+    userPrefix = "static",
   } = params;
   // The user-facing `resolution` parameter is currently a no-op: Strava only
   // accepts low | medium | high (rejects "all") and we always fetch high to
@@ -162,10 +164,9 @@ export async function fetchActivityStreams(
     ALL_STREAM_TYPES.includes(t)
   );
 
-  // Per-activity cache (activities are immutable). The cached payload always
-  // contains the full safe stream set Strava actually returned; we filter to
-  // the user's requested types on the way out.
-  const cacheKey = `streams:${activityId}:all`;
+  // Cache key includes user prefix so entries can be deleted on token revocation.
+  // The cached payload contains the full safe stream set Strava returned.
+  const cacheKey = `${userPrefix}:streams:${activityId}:all`;
   const cached = await readCachedStreams(streamCache, cacheKey);
 
   let rawStreams: Record<string, RawStream>;

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -128,10 +128,12 @@ export async function fetchFilteredActivities(
 export function registerStravaTools(
   server: McpServer,
   client: StravaClient,
-  env: Env
+  env: Env,
+  userOAuthToken?: string
 ): void {
   const streamCache = env.STREAM_CACHE;
   const tokenCache = env.TOKEN_CACHE;
+  const userPrefix = userOAuthToken ?? "static";
   // Issue #3 — get_athlete_profile
   server.tool(
     "get_athlete_profile",
@@ -309,6 +311,7 @@ export function registerStravaTools(
           laps,
           timeRangeSeconds: time_range_seconds,
           distanceRangeMeters: distance_range_meters,
+          userPrefix,
         });
         return ok(result);
       } catch (err) {

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -742,6 +742,10 @@ interface HealthRateLimit {
   shortTermUsage: number;
   dailyLimit: number;
   dailyUsage: number;
+  readShortTermLimit?: number;
+  readShortTermUsage?: number;
+  readDailyLimit?: number;
+  readDailyUsage?: number;
   updated_at: number | null;
 }
 

--- a/src/strava/types.ts
+++ b/src/strava/types.ts
@@ -37,6 +37,11 @@ export interface StravaRateLimitInfo {
   shortTermUsage: number;
   dailyLimit: number;
   dailyUsage: number;
+  // Read-specific tier (subset of overall — the binding limit for read-only apps)
+  readShortTermLimit?: number;
+  readShortTermUsage?: number;
+  readDailyLimit?: number;
+  readDailyUsage?: number;
 }
 
 export interface StravaError {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,4 +7,5 @@ export interface Env {
   STRAVA_CLIENT_SECRET: string;
   STRAVA_REFRESH_TOKEN: string;
   LOG_LEVEL?: string;
+  WEBHOOK_VERIFY_TOKEN: string;
 }

--- a/test/strava-client.test.ts
+++ b/test/strava-client.test.ts
@@ -26,6 +26,7 @@ function makeEnv(kv: KVNamespace): Env {
     STRAVA_CLIENT_ID: "client123",
     STRAVA_CLIENT_SECRET: "secret456",
     STRAVA_REFRESH_TOKEN: "refresh789",
+    WEBHOOK_VERIFY_TOKEN: "webhook-secret",
   };
 }
 

--- a/test/streams.test.ts
+++ b/test/streams.test.ts
@@ -91,7 +91,7 @@ describe("fetchActivityStreams", () => {
 
     // Second call — should hit cache
     const cachedValue = (kv.put as ReturnType<typeof vi.fn>).mock.calls[0][1] as string;
-    const kv2 = makeKv({ "streams:123:all": cachedValue });
+    const kv2 = makeKv({ "static:streams:123:all": cachedValue });
     const client2 = makeClient(fixture);
     await fetchActivityStreams(client2, kv2, { activityId: 123 });
     expect((client2.fetch as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
@@ -238,7 +238,7 @@ describe("fetchActivityStreams", () => {
       },
       presentTypes: ["time", "distance", "heartrate", "cadence"],
     };
-    const kv = makeKv({ "streams:42:all": JSON.stringify(fullPayload) });
+    const kv = makeKv({ "static:streams:42:all": JSON.stringify(fullPayload) });
     const client = {
       fetch: vi.fn(),
       lastRateLimitInfo: null,
@@ -277,7 +277,7 @@ describe("fetchActivityStreams", () => {
       time: { type: "time", data: [0, 1, 2], series_type: "time", original_size: 3, resolution: "high" },
       distance: { type: "distance", data: [0, 5, 10], series_type: "time", original_size: 3, resolution: "high" },
     };
-    const kv = makeKv({ "streams:7:all": JSON.stringify(legacy) });
+    const kv = makeKv({ "static:streams:7:all": JSON.stringify(legacy) });
     const client = {
       fetch: vi.fn(),
       lastRateLimitInfo: null,
@@ -302,7 +302,7 @@ describe("fetchActivityStreams", () => {
       },
       presentTypes: ["time", "heartrate"],
     };
-    const kv = makeKv({ "streams:55:all": JSON.stringify(cached) });
+    const kv = makeKv({ "static:streams:55:all": JSON.stringify(cached) });
     const client = {
       fetch: vi.fn(),
       lastRateLimitInfo: null,

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -67,6 +67,7 @@ function makeEnv(opts: HarnessOptions = {}): import("../src/types.js").Env {
     STRAVA_CLIENT_ID: "client123",
     STRAVA_CLIENT_SECRET: "secret456",
     STRAVA_REFRESH_TOKEN: "refresh789",
+    WEBHOOK_VERIFY_TOKEN: "webhook-secret",
   };
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,6 +31,6 @@
   ],
 
   "observability": {
-    "enabled": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary

- **Token revocation** (`POST /oauth/revoke`, RFC 7009): deletes oauth token, Strava access token cache, and all stream cache entries for the user
- **Strava deauthorization webhook** (`GET /webhook` + `POST /webhook`): when a user removes the app from Strava settings, Strava calls our webhook and we immediately delete all their data — completing the GDPR right-to-erasure loop
- **Athlete→token reverse index**: stored at token issue time so the webhook can identify which user deauthorized
- **User-scoped stream cache keys**: cache entries are prefixed by OAuth token, enabling per-user deletion on revocation
- **Observability disabled**: `wrangler.jsonc` `observability.enabled: false` — prevents token values appearing in Cloudflare logs
- **Read rate limit tier**: parses `X-ReadRateLimit-Limit` / `X-ReadRateLimit-Usage` headers alongside the overall limits; exposed in `health` tool output and 429 error messages — fixes misleading "93 requests left" when reads are actually exhausted
- **GitHub Pages**: `docs/index.html` (landing page with Strava attribution) + `docs/privacy.html` (GDPR-compliant privacy policy)
- **README**: webhook registration instructions, `WEBHOOK_VERIFY_TOKEN` secret documented

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:run` — 121 tests pass
- [ ] Deploy and set `WEBHOOK_VERIFY_TOKEN` secret
- [ ] Register Strava webhook subscription via `curl`
- [ ] Enable GitHub Pages (docs/ folder on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)