### PR TITLE
[#33] MCP Resources, Prompts, get_cache_stats, and health fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [Deploy your own](#deploy-your-own) below to run your own instance on Cloudf
 
 ## Available tools
 
-19 read-only tools covering activities, streams, segments, routes, gear, and diagnostics.
+20 read-only tools covering activities, streams, segments, routes, gear, and diagnostics.
 
 | Tool | Returns |
 |------|---------|
@@ -63,7 +63,29 @@ See [Deploy your own](#deploy-your-own) below to run your own instance on Cloudf
 | `list_routes` | Your saved routes with pagination |
 | `get_route_details` | Full route metadata plus stream data (latlng, distance, altitude) |
 | `list_gear` | Bikes and shoes with mileage |
+| `get_cache_stats` | Which activity IDs have cached streams for the current user, plus rate-limit budget |
 | `health` | Diagnostics: athlete ID, Strava rate limits (overall + read tier), cache stats, worker version |
+
+### Resources
+
+Two persistent [MCP resources](https://modelcontextprotocol.io/docs/concepts/resources) are exposed as URIs. Clients that support resources can subscribe to these and read them without a tool call — useful as always-available context.
+
+| URI | Contents |
+|-----|----------|
+| `strava://athlete` | Your Strava athlete profile (name, location, weight, FTP, measurement preference) |
+| `strava://stats` | Lifetime statistics: recent, YTD, and all-time totals by sport |
+
+### Prompts
+
+Five [MCP prompts](https://modelcontextprotocol.io/docs/concepts/prompts) are pre-wired for common analyses. Clients that support prompts (e.g. Claude's prompt picker) surface these as one-click templates.
+
+| Prompt | What it asks |
+|--------|-------------|
+| `analyse-recent-training` | Training load, trends, and patterns over the last N days |
+| `pr-history` | PR progression at a target distance, sorted fastest-first |
+| `compare-weeks` | Side-by-side comparison of this week vs last week |
+| `activity-deep-dive` | Thorough breakdown of a single activity: pacing, HR, zones, laps |
+| `fitness-trends` | Long-range fitness trends across N months |
 
 ### Stream data
 

--- a/src/strava/tools.ts
+++ b/src/strava/tools.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ReadResourceResult, GetPromptResult } from "@modelcontextprotocol/sdk/types.js";
 import { StravaApiError, RATE_LIMIT_KV_KEY } from "./client.js";
 import type { StravaClient } from "./client.js";
 import { handleStravaError, assertOk } from "./errors.js";
@@ -679,6 +680,229 @@ export function registerStravaTools(
     }
   );
 
+  // get_cache_stats — per-user view of which activities have cached streams.
+  server.tool(
+    "get_cache_stats",
+    "Lists activity IDs that have cached stream data for the current user. Also shows current Strava rate-limit budget. Useful for understanding what's already cached before issuing stream fetches.",
+    {},
+    async () => {
+      try {
+        const listed = await streamCache.list({ prefix: `${userPrefix}:streams:`, limit: KV_LIST_LIMIT });
+        const activityIds: number[] = [];
+        for (const k of listed.keys) {
+          // Key format: {userPrefix}:streams:{activityId}:all
+          const parts = k.name.split(":");
+          const idPart = parts[2];
+          if (idPart) {
+            const id = parseInt(idPart, 10);
+            if (!Number.isNaN(id)) activityIds.push(id);
+          }
+        }
+        activityIds.sort((a, b) => b - a);
+        const rateLimit = await readLatestRateLimit(tokenCache);
+        return ok({
+          cached_stream_count: activityIds.length,
+          cached_activity_ids: activityIds,
+          list_truncated: !listed.list_complete,
+          rate_limit: rateLimit,
+        });
+      } catch (err) {
+        return handleStravaError(err);
+      }
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // MCP Resources — persistent data URIs the client can subscribe to and read
+  // without a tool call. Useful as always-available context for the LLM.
+  // ---------------------------------------------------------------------------
+
+  server.registerResource(
+    "athlete-profile",
+    "strava://athlete",
+    {
+      title: "Athlete Profile",
+      description: "Your Strava athlete profile: name, location, weight, FTP, measurement preference, and account details.",
+      mimeType: "application/json",
+    },
+    async (uri): Promise<ReadResourceResult> => {
+      const res = await client.fetch("/athlete");
+      assertOk(res);
+      const profile = await res.json();
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: "application/json",
+            text: JSON.stringify(profile, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerResource(
+    "athlete-stats",
+    "strava://stats",
+    {
+      title: "Athlete Statistics",
+      description: "Your Strava lifetime statistics: recent (4-week), YTD, and all-time totals for runs, rides, and swims.",
+      mimeType: "application/json",
+    },
+    async (uri): Promise<ReadResourceResult> => {
+      const athleteRes = await client.fetch("/athlete");
+      assertOk(athleteRes);
+      const athlete = (await athleteRes.json()) as { id: number };
+      const statsRes = await client.fetch(`/athletes/${athlete.id}/stats`);
+      assertOk(statsRes);
+      const stats = await statsRes.json();
+      return {
+        contents: [
+          {
+            uri: uri.toString(),
+            mimeType: "application/json",
+            text: JSON.stringify(stats, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // MCP Prompts — pre-defined query templates users can invoke from their
+  // client's prompt picker. Each injects context and frames the question so
+  // the model has everything it needs to answer immediately.
+  // ---------------------------------------------------------------------------
+
+  server.registerPrompt(
+    "analyse-recent-training",
+    {
+      title: "Analyse Recent Training",
+      description: "Comprehensive analysis of training load, trends, and patterns over a recent window.",
+      argsSchema: {
+        days: z.string().optional().describe("Number of days to look back (default: 28)"),
+        activity_type: z.string().optional().describe("Limit to a sport, e.g. 'Run' or 'Ride'"),
+      },
+    },
+    ({ days, activity_type }): GetPromptResult => {
+      const window = days ?? "28";
+      const sport = activity_type ? ` for ${activity_type} activities` : "";
+      return {
+        description: `Analyse training over the last ${window} days`,
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Please analyse my Strava training${sport} over the last ${window} days.\n\nFetch my recent activities and give me:\n1. Volume summary (distance, time, elevation)\n2. Weekly training load trends\n3. Heart rate and pace patterns\n4. Notable workouts (longest, hardest, best paced)\n5. Any observations or recommendations\n\nUse the strava-mcp tools to pull the data, then do the analysis yourself.`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerPrompt(
+    "pr-history",
+    {
+      title: "PR History",
+      description: "Show PR progression at a target race distance over time, sorted fastest first.",
+      argsSchema: {
+        distance: z.string().describe("Strava best-effort name, e.g. '5k', '10k', 'Half-Marathon', 'Marathon'"),
+      },
+    },
+    ({ distance }): GetPromptResult => {
+      return {
+        description: `PR history at ${distance}`,
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Show me my PR progression at ${distance} over all time.\n\nUse get_athlete_best_efforts to pull all efforts at this distance, then:\n1. List them sorted fastest-first with date and activity name\n2. Identify the current PR and when it was set\n3. Show improvement over time (first effort vs. current PR)\n4. Note any PR streaks or gaps in racing\n5. If I have enough data, extrapolate when I might crack the next milestone`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerPrompt(
+    "compare-weeks",
+    {
+      title: "Compare This Week vs Last Week",
+      description: "Side-by-side comparison of training volume and quality between the current and previous week.",
+      argsSchema: {},
+    },
+    (): GetPromptResult => {
+      return {
+        description: "Compare this week vs last week",
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Compare my training this week against last week.\n\nUse get_athlete_summary with granularity 'week' (or fetch activities directly) and compare:\n1. Total distance, time, and elevation\n2. Average pace / speed\n3. Average heart rate\n4. Number of sessions and sport breakdown\n5. Notable differences — is this week a step-up, recovery, or similar load?`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerPrompt(
+    "activity-deep-dive",
+    {
+      title: "Activity Deep Dive",
+      description: "Thorough breakdown of a single activity: pacing, HR zones, laps, effort distribution, and segment highlights.",
+      argsSchema: {
+        activity_id: z.string().describe("The Strava activity ID (numeric)"),
+      },
+    },
+    ({ activity_id }): GetPromptResult => {
+      return {
+        description: `Deep dive: activity ${activity_id}`,
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Give me a thorough breakdown of Strava activity ${activity_id}.\n\nFetch details, streams, laps, and zones, then analyse:\n1. Overall stats (distance, time, pace/speed, elevation, HR)\n2. Pacing strategy — positive or negative split? Consistent?\n3. Heart rate progression throughout the effort\n4. Lap-by-lap breakdown if laps are present\n5. Zone distribution (time in each HR zone)\n6. Any notable segment efforts or PRs\n7. How does this effort compare to typical for this distance?`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
+  server.registerPrompt(
+    "fitness-trends",
+    {
+      title: "Fitness Trends",
+      description: "Long-range trend analysis across months: volume progression, pace improvement, HR efficiency.",
+      argsSchema: {
+        months: z.string().optional().describe("Number of months to look back (default: 6)"),
+        activity_type: z.string().optional().describe("Limit to a sport, e.g. 'Run' or 'Ride'"),
+      },
+    },
+    ({ months, activity_type }): GetPromptResult => {
+      const window = months ?? "6";
+      const sport = activity_type ? ` ${activity_type}` : "";
+      return {
+        description: `${sport} fitness trends over ${window} months`,
+        messages: [
+          {
+            role: "user",
+            content: {
+              type: "text",
+              text: `Analyse my${sport} fitness trends over the last ${window} months.\n\nUse get_athlete_summary with monthly granularity, then look at:\n1. Month-by-month volume progression (distance, time, elevation)\n2. Pace or speed improvement trend\n3. Heart rate efficiency (same pace, lower HR = improved fitness)\n4. Consistency: any gaps, big jumps, or tapers?\n5. Peak month vs. current: am I building, maintaining, or declining?\n6. Suggested focus areas for the next block based on what you see`,
+            },
+          },
+        ],
+      };
+    }
+  );
+
   // D2 — health: deployment + cache + rate-limit snapshot for diagnostics.
   server.tool(
     "health",
@@ -847,7 +1071,7 @@ async function readCacheStats(
   let streamEntries = 0;
   let lapEntries = 0;
   for (const k of result.keys) {
-    if (k.name.startsWith("streams:")) streamEntries++;
+    if (k.name.includes(":streams:")) streamEntries++;
     else if (k.name.startsWith("activity:")) activitySummaries++;
     else if (k.name.startsWith("laps:")) lapEntries++;
   }

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -800,8 +800,8 @@ describe("health (D2)", () => {
 
   it("counts cache entries by prefix", async () => {
     const streamCache = mockKv();
-    await streamCache.put("streams:1:all", "{}");
-    await streamCache.put("streams:2:all", "{}");
+    await streamCache.put("static:streams:1:all", "{}");
+    await streamCache.put("static:streams:2:all", "{}");
     await streamCache.put("activity:1:summary", "{}");
     await streamCache.put("laps:1", "[]");
     await streamCache.put("laps:2", "[]");
@@ -815,5 +815,165 @@ describe("health (D2)", () => {
       await h.mcpClient.callTool({ name: "health", arguments: {} })
     ) as { cache: { activity_summaries: number; stream_entries: number; lap_entries: number } };
     expect(data.cache).toEqual({ activity_summaries: 1, stream_entries: 2, lap_entries: 3 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_cache_stats
+// ---------------------------------------------------------------------------
+
+describe("get_cache_stats", () => {
+  it("returns empty list when no streams are cached", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_cache_stats", arguments: {} })
+    ) as { cached_stream_count: number; cached_activity_ids: number[] };
+    expect(data.cached_stream_count).toBe(0);
+    expect(data.cached_activity_ids).toEqual([]);
+  });
+
+  it("lists activity IDs with cached streams, sorted newest-first", async () => {
+    const streamCache = mockKv();
+    await streamCache.put("static:streams:100:all", "{}");
+    await streamCache.put("static:streams:200:all", "{}");
+    await streamCache.put("static:streams:50:all", "{}");
+    await streamCache.put("activity:100:summary", "{}"); // should not appear
+    const h = await createHarness([], { streamCache });
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_cache_stats", arguments: {} })
+    ) as { cached_stream_count: number; cached_activity_ids: number[] };
+    expect(data.cached_stream_count).toBe(3);
+    expect(data.cached_activity_ids).toEqual([200, 100, 50]);
+  });
+
+  it("does not count another user's cached streams", async () => {
+    const streamCache = mockKv();
+    await streamCache.put("static:streams:100:all", "{}");
+    await streamCache.put("otheruser:streams:999:all", "{}");
+    // createHarness uses no userOAuthToken, so userPrefix = "static"
+    const h = await createHarness([], { streamCache });
+    afterEach(() => h.close());
+    const data = parseResult(
+      await h.mcpClient.callTool({ name: "get_cache_stats", arguments: {} })
+    ) as { cached_stream_count: number; cached_activity_ids: number[] };
+    expect(data.cached_stream_count).toBe(1);
+    expect(data.cached_activity_ids).toEqual([100]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP Resources
+// ---------------------------------------------------------------------------
+
+describe("MCP Resources", () => {
+  it("lists strava://athlete and strava://stats resources", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const { resources } = await h.mcpClient.listResources();
+    const uris = resources.map((r) => r.uri);
+    expect(uris).toContain("strava://athlete");
+    expect(uris).toContain("strava://stats");
+  });
+
+  it("strava://athlete resource returns athlete JSON", async () => {
+    const profile = { id: 42, username: "ada", firstname: "Ada", lastname: "L" };
+    const h = await createHarness([["/athlete", profile]]);
+    afterEach(() => h.close());
+    const result = await h.mcpClient.readResource({ uri: "strava://athlete" });
+    expect(result.contents).toHaveLength(1);
+    const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+    expect(content.uri).toBe("strava://athlete");
+    expect(content.mimeType).toBe("application/json");
+    const parsed = JSON.parse(content.text);
+    expect(parsed.id).toBe(42);
+    expect(parsed.username).toBe("ada");
+  });
+
+  it("strava://stats resource returns stats JSON", async () => {
+    const stats = { recent_run_totals: { distance: 50000 }, all_run_totals: { distance: 5000000 } };
+    const h = await createHarness([
+      ["/athlete", { id: 7 }],
+      ["/athletes/7/stats", stats],
+    ]);
+    afterEach(() => h.close());
+    const result = await h.mcpClient.readResource({ uri: "strava://stats" });
+    const content = result.contents[0] as { text: string };
+    const parsed = JSON.parse(content.text);
+    expect(parsed.recent_run_totals.distance).toBe(50000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP Prompts
+// ---------------------------------------------------------------------------
+
+describe("MCP Prompts", () => {
+  const EXPECTED_PROMPTS = [
+    "analyse-recent-training",
+    "pr-history",
+    "compare-weeks",
+    "activity-deep-dive",
+    "fitness-trends",
+  ];
+
+  it("lists all expected prompts", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const { prompts } = await h.mcpClient.listPrompts();
+    const names = prompts.map((p) => p.name);
+    for (const name of EXPECTED_PROMPTS) {
+      expect(names).toContain(name);
+    }
+  });
+
+  it("analyse-recent-training returns a user message with days in it", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const result = await h.mcpClient.getPrompt({
+      name: "analyse-recent-training",
+      arguments: { days: "14", activity_type: "Run" },
+    });
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe("user");
+    const content = result.messages[0].content as { type: string; text: string };
+    expect(content.type).toBe("text");
+    expect(content.text).toContain("14");
+    expect(content.text).toContain("Run");
+  });
+
+  it("pr-history returns a user message mentioning the distance", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const result = await h.mcpClient.getPrompt({
+      name: "pr-history",
+      arguments: { distance: "10k" },
+    });
+    expect(result.messages[0].role).toBe("user");
+    const content = result.messages[0].content as { type: string; text: string };
+    expect(content.text).toContain("10k");
+  });
+
+  it("activity-deep-dive includes the activity_id in the message", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const result = await h.mcpClient.getPrompt({
+      name: "activity-deep-dive",
+      arguments: { activity_id: "12345678" },
+    });
+    const content = result.messages[0].content as { type: string; text: string };
+    expect(content.text).toContain("12345678");
+  });
+
+  it("compare-weeks and fitness-trends work with no required args", async () => {
+    const h = await createHarness([]);
+    afterEach(() => h.close());
+    const [compareResult, trendsResult] = await Promise.all([
+      h.mcpClient.getPrompt({ name: "compare-weeks", arguments: {} }),
+      h.mcpClient.getPrompt({ name: "fitness-trends", arguments: {} }),
+    ]);
+    expect(compareResult.messages).toHaveLength(1);
+    expect(trendsResult.messages).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- **MCP Resources**: `strava://athlete` and `strava://stats` — persistent URIs clients can read as always-available context without a tool call
- **MCP Prompts**: 5 pre-defined analysis templates (`analyse-recent-training`, `pr-history`, `compare-weeks`, `activity-deep-dive`, `fitness-trends`) — one-click queries in clients that surface a prompt picker
- **`get_cache_stats` tool**: per-user list of which activity IDs have cached streams, plus current rate-limit budget
- **Health tool bug fix**: stream cache count was always 0 because key format changed to `{userPrefix}:streams:{id}:all` but check still used `startsWith("streams:")`; fixed to `includes(":streams:")`

## Test plan

- [ ] All 132 tests pass (`pnpm test:run`)
- [ ] `listResources` returns both URIs
- [ ] `readResource("strava://athlete")` returns athlete JSON
- [ ] `readResource("strava://stats")` returns stats JSON
- [ ] `listPrompts` returns all 5 prompts
- [ ] Each prompt returns a user message with the correct interpolated values
- [ ] `get_cache_stats` lists only the current user's activity IDs (not other users')
- [ ] `health` tool now correctly counts stream entries

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)